### PR TITLE
Factor somatic variant callers in the same GADT variant

### DIFF
--- a/src/app/main.ml
+++ b/src/app/main.ml
@@ -36,7 +36,7 @@ let crazy_somatic_example ~normal_fastqs ~tumor_fastqs ~dataset =
           mutect bam_pair;
           somaticsniper bam_pair;
           somaticsniper ~prior_probability:0.001 ~theta:0.95 bam_pair;
-          varscan bam_pair;
+          varscan_somatic bam_pair;
         ])
   in
   vcfs
@@ -70,7 +70,7 @@ let global_named_examples: (string * example_pipeline) list = [
   "somatic-simple-varscan",
   `Somatic_from_fastqs
     (simple_somatic_example
-       ~variant_caller:Biokepi_pipeline.Construct.varscan);
+       ~variant_caller:Biokepi_pipeline.Construct.varscan_somatic);
   "somatic-simple-mutect",
   `Somatic_from_fastqs
     (simple_somatic_example

--- a/src/lib/biokepi_common_pipelines.ml
+++ b/src/lib/biokepi_common_pipelines.ml
@@ -55,7 +55,7 @@ module Somatic = struct
             mutect bam_pair;
             somaticsniper bam_pair;
             somaticsniper ~prior_probability:0.001 ~theta:0.95 bam_pair;
-            varscan bam_pair;
+            varscan_somatic bam_pair;
             strelka ~configuration:Strelka.Configuration.exome_default bam_pair;
           ])
     in

--- a/src/lib/biokepi_target_library.ml
+++ b/src/lib/biokepi_target_library.ml
@@ -585,7 +585,7 @@ module Varscan = struct
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNORMAL\tTUMOR
 "
 
-  let on_region
+  let somatic_on_region
       ~run_with ?adjust_mapq ~normal ~tumor ~result_prefix region =
     let open Ketrew.EDSL in
     let name = Filename.basename result_prefix in
@@ -650,10 +650,10 @@ module Varscan = struct
     in
     varscan_filter
 
-  let map_reduce ~run_with ?adjust_mapq ~normal ~tumor ~result_prefix () =
+  let somatic_map_reduce ~run_with ?adjust_mapq ~normal ~tumor ~result_prefix () =
     let run_on_region region =
       let result_prefix = result_prefix ^ "-" ^ Region.to_filename region in
-      on_region ~run_with
+      somatic_on_region ~run_with
         ?adjust_mapq ~normal ~tumor ~result_prefix region in
     let targets = List.map Region.all_chromosomes_b37 ~f:run_on_region in
     let final_vcf = result_prefix ^ "-merged.vcf" in


### PR DESCRIPTION

This should make it easier to add somatic variant callers.
(i.e. this kind of dev but somatic
https://github.com/hammerlab/biokepi/compare/add-haplotype-caller)

- a new Biokepi variant caller would just have to create a function in `Biokepi_pipeline.Construct`
- anyone can create that kind of step without having to modify the library (as long as they comply with the API in `Somatic_variant_caller.t`)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/9)
<!-- Reviewable:end -->
