### PR TITLE
Fix samtools sort flag

### DIFF
--- a/src/lib/biokepi_target_library.ml
+++ b/src/lib/biokepi_target_library.ml
@@ -226,8 +226,8 @@ module Samtools = struct
     let dest_prefix =
       sprintf "%s-%s" (Filename.chop_suffix source ".bam") "sorted" in
     let destination = sprintf "%s.%s" dest_prefix "bam" in
-    let sort_with_threads = sprintf "sort -@ %d" processors in
-    let make_command src des = [sort_with_threads; src; dest_prefix] in
+    let with_threads = sprintf "-@ %d" processors in
+    let make_command src des = ["sort"; with_threads; src; dest_prefix] in
     do_on_bam ~run_with bam_file ~destination ~make_command
 
   let index_to_bai ~(run_with:Machine.t) bam_file =


### PR DESCRIPTION
`samtools` was not happy with the quoting that happened

```
'samtools' 'sort -@ 1' '/hpc/users/ahujaa01/dream/synthetic.challenge.set2.normal.bam' '/hpc/users/ahujaa01/dream/synthetic.challenge.set2.normal-sorted'
````
does not work, but 

```
'samtools' 'sort' '-@ 1' '/hpc/users/ahujaa01/dream/synthetic.challenge.set2.normal.bam' '/hpc/users/ahujaa01/dream/synthetic.challenge.set2.normal-sorted'
```
does


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/16)
<!-- Reviewable:end -->
