### PR TITLE
Add b37 reference with decoy sequences

### DIFF
--- a/src/lib/biokepi_pipeline.ml
+++ b/src/lib/biokepi_pipeline.ml
@@ -44,7 +44,7 @@ module Somatic_variant_caller = struct
     configuration_json: json;
     configuration_name: string;
     make_target:
-      reference_build: [`B37 | `B38 | `hg19 ] -> 
+      reference_build: [`B37 | `B38 | `hg19 | `B37decoy ] -> 
       run_with:Biokepi_run_environment.Machine.t ->
       normal:Ketrew.EDSL.user_target ->
       tumor:Ketrew.EDSL.user_target ->

--- a/src/lib/biokepi_region.ml
+++ b/src/lib/biokepi_region.ml
@@ -132,7 +132,7 @@ let all_chromosomes_hg19 = [
 
 let major_contigs ~reference_build = 
   match reference_build with 
-    | `B37 -> all_chromosomes_b37
+    | (`B37 | `B37decoy) -> all_chromosomes_b37
     | `B38 -> all_chromosomes_b37
     | `hg19 -> all_chromosomes_hg19
 


### PR DESCRIPTION
This adds an alternative B37 reference that contains decoy sequences for improved alignment and epstein-barr virus sequence

More details on the differences are here: 
https://wiki.dnanexus.com/Scientific-Notes/human-genome#What-exactly-is-%22human-DNA%22%3F

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/21)
<!-- Reviewable:end -->
