### PR TITLE
Adding multi-threading option to GATK tools

### DIFF
--- a/src/lib/biokepi_pipeline.ml
+++ b/src/lib/biokepi_pipeline.ml
@@ -347,13 +347,13 @@ let rec compile_aligner_step
   | Gatk_indel_realigner bam ->
     let input_bam = compile_aligner_step ~processors ~work_dir ~reference_build ?is ~machine bam in
     let output_bam = result_prefix ^ ".bam" in
-    Gatk.indel_realigner ~reference_build ~run_with:machine input_bam ~compress:false
+    Gatk.indel_realigner ~processors ~reference_build ~run_with:machine input_bam ~compress:false
       ~output_bam
   | Gatk_bqsr bam ->
     let input_bam = compile_aligner_step ~processors ~work_dir ~reference_build ?is ~machine bam in
     let output_bam = result_prefix ^ ".bam" in
     Gatk.base_quality_score_recalibrator
-      ~run_with:machine ~reference_build ~input_bam ~output_bam
+      ~run_with:machine ~processors ~reference_build ~input_bam ~output_bam
   | Picard_mark_duplicates bam ->
     let input_bam = compile_aligner_step ~processors ~work_dir ~reference_build ?is ~machine bam in
     let output_bam = result_prefix ^ ".bam" in

--- a/src/lib/biokepi_util_targets.ml
+++ b/src/lib/biokepi_util_targets.ml
@@ -144,12 +144,13 @@ module Picard = struct
     let picard_jar = Machine.get_tool run_with "picard" in
     let metrics_path =
       sprintf "%s.%s" (Filename.chop_suffix output_bam ".bam") ".metrics" in
+    let sorted_bam = Samtools.sort_bam ~run_with input_bam in
     let program =
       Program.(Tool.(init picard_jar) &&
                shf "java -jar $PICARD_JAR MarkDuplicates \
                     VALIDATION_STRINGENCY=LENIENT \
                     INPUT=%s OUTPUT=%s METRICS_FILE=%s"
-                 (Filename.quote input_bam#product#path)
+                 (Filename.quote sorted_bam#product#path)
                  (Filename.quote output_bam)
                  metrics_path) in
     let make = Machine.run_program run_with program in
@@ -158,7 +159,7 @@ module Picard = struct
       ~name:(sprintf "picard-markdups-%s"
                Filename.(basename input_bam#product#path))
       ~host ~make
-      ~dependencies:[input_bam; Tool.(ensure picard_jar)]
+      ~dependencies:[sorted_bam; input_bam; Tool.(ensure picard_jar);]
       ~if_fails_activate:[Remove.file ~run_with output_bam;
                           Remove.file ~run_with metrics_path;]
     

--- a/src/lib/biokepi_util_targets.ml
+++ b/src/lib/biokepi_util_targets.ml
@@ -207,7 +207,7 @@ module Gatk = struct
     let intervals_file =
       Filename.chop_suffix input_bam#product#path ".bam" ^ "-target.intervals"
     in
-    let sorted_bam = Samtools.sort_bam ~run_with input_bam in
+    let sorted_bam = Samtools.sort_bam ~run_with ~processors input_bam in
     let make =
       Machine.run_program run_with ~name
         Program.(
@@ -265,7 +265,7 @@ module Gatk = struct
     let recal_data_table =
       Filename.chop_suffix input_bam#product#path ".bam" ^ "-recal_data.table"
     in
-    let sorted_bam = Samtools.sort_bam ~run_with input_bam in
+    let sorted_bam = Samtools.sort_bam ~run_with ~processors input_bam in
     let make =
       Machine.run_program run_with ~name
         Program.(


### PR DESCRIPTION
- Add `-nt` option to IndelRealaignment
- Add `-nct` to BQSR

Also added a sorted bam requirement to mark duplicates

This is based on the suggested flags from http://gatkforums.broadinstitute.org/discussion/1975/how-can-i-use-parallelism-to-make-gatk-tools-run-faster