### PR TITLE
Experiment:  `Common.KEDSL`

### DIFF
--- a/src/lib/biokepi_common.ml
+++ b/src/lib/biokepi_common.ml
@@ -31,3 +31,124 @@ let failwithf fmt = ksprintf failwith fmt
 module Unique_id = struct
   include Ketrew_pervasives.Unique_id
 end
+
+
+(**
+
+   This is an experimental extension of Ketrew's EDSL. If we're happy
+   with it we'll push it upstream.
+
+   The idea is carry around a type parameter to have arbitrary products.
+
+*)
+module KEDSL = struct
+
+  include Ketrew.EDSL
+  module Command = Ketrew_target.Command
+
+  type 'product workflow_node = <
+    product : 'product;
+    target: user_target;
+  > constraint 'product = < is_done : Condition.t option ; .. >
+
+  type workflow_edge =
+    | Depends_on: 'a workflow_node -> workflow_edge
+    | On_success_activate: _ workflow_node -> workflow_edge
+    | On_failure_activate: _ workflow_node -> workflow_edge
+    | Empty_edge: workflow_edge
+
+  let depends_on l =  Depends_on l
+  let on_success_activate n = On_success_activate n
+  let on_failure_activate n = On_failure_activate n
+
+  type nothing = < is_done : Condition.t option >
+  let nothing  = object method is_done = None end
+
+  let workflow_node
+      ?active
+      ?make ?done_when ?metadata
+      ?equivalence
+      ?(tags=[]) ?name ?(edges=[])
+      (product: 'product) : 'product workflow_node =
+    let user_target =
+      let done_when =
+        match done_when with
+        | Some s -> Some s
+        | None -> product#is_done
+      in
+      let depends_on =
+        List.filter_map edges ~f:(function
+          | Depends_on we -> Some we#target
+          | _ -> None) in
+      let on_success_activate =
+        List.filter_map edges ~f:(function
+          | On_success_activate we -> Some we#target
+          | _ -> None) in
+      let on_failure_activate =
+        List.filter_map edges ~f:(function
+          | On_failure_activate we -> Some we#target
+          | _ -> None) in
+      let actual_name = Option.value name ~default:"Biokepi" in
+      let tags = "biokepi" :: tags in
+      target
+        actual_name
+        ?equivalence ~tags
+        ~on_success_activate ~on_failure_activate ~depends_on
+        ?active ?make ?metadata ?done_when
+    in
+    object
+      method product = product
+      method target = user_target
+    end
+
+
+  let target _ = `Please_KEDSL_workflow
+  let file_target _ = `Please_KEDSL_workflow
+
+  type single_file = <
+    exists: Ketrew_target.Condition.t;
+    is_done: Ketrew_target.Condition.t option;
+    path : string;
+    is_bigger_than: int -> Ketrew_target.Condition.t;
+  >
+  let single_file ?(host= Host.tmp_on_localhost) path : single_file =
+    let basename = Filename.basename path in
+    object
+      val vol =
+        Ketrew_target.Volume.(
+          create ~host
+            ~root:(Ketrew.Path.absolute_directory_exn (Filename.dirname path))
+            (file basename))
+      method path = path
+      method exists = `Volume_exists vol
+      method is_done = Some (`Volume_exists vol)
+      method is_bigger_than n = `Volume_size_bigger_than (vol, n)
+    end
+
+  let forget_product node : nothing workflow_node =
+    object method product = nothing  method target = node#target end
+
+  type file_workflow = single_file workflow_node
+  type phony_workflow = nothing workflow_node
+
+
+  type fastq_reads = <
+    is_done: Ketrew_target.Condition.t option;
+    paths : string * (string option);
+  >
+  let fastq_reads ?host r1 r2_opt =
+    object
+      val r1_file = single_file ?host r1
+      val r2_file_opt = Option.map r2_opt ~f:(single_file ?host)
+      method paths = (r1, r2_opt)
+      method is_done =
+        Some (match r2_file_opt with
+          | Some r2 -> `And [r1_file#exists; r2#exists]
+          | None -> r1_file#exists)
+    end
+
+
+end
+(** and then we forbid any other access to Ketrew, to force everything
+    to throught the above module. *)
+module Ketrew = struct end

--- a/src/lib/biokepi_common.ml
+++ b/src/lib/biokepi_common.ml
@@ -136,7 +136,7 @@ module KEDSL = struct
     is_done: Ketrew_target.Condition.t option;
     paths : string * (string option);
   >
-  let fastq_reads ?host r1 r2_opt =
+  let fastq_reads ?host r1 r2_opt : fastq_reads =
     object
       val r1_file = single_file ?host r1
       val r2_file_opt = Option.map r2_opt ~f:(single_file ?host)
@@ -145,6 +145,21 @@ module KEDSL = struct
         Some (match r2_file_opt with
           | Some r2 -> `And [r1_file#exists; r2#exists]
           | None -> r1_file#exists)
+    end
+
+  type bam_file = <
+    is_done: Ketrew_target.Condition.t option;
+    path : string;
+    sorting: [ `Coordinate | `Read_name ] option;
+    content_type: [ `DNA | `RNA ];
+  >
+  let bam_file ?host ?sorting ?(contains=`DNA) path : bam_file =
+    object
+      val file = single_file ?host path
+      method path = file#path
+      method is_done = file#is_done
+      method sorting = sorting
+      method content_type = contains
     end
 
 

--- a/src/lib/biokepi_pipeline.ml
+++ b/src/lib/biokepi_pipeline.ml
@@ -380,6 +380,9 @@ let rec compile_aligner_step
       let open KEDSL in
       workflow_node (fastq_reads ~host:Machine.(as_host machine)
                        r1#product#path (Some r2#product#path))
+        ~name:(sprintf "pairing %s and %s"
+                 (Filename.basename r1#product#path)
+                 (Filename.basename r2#product#path))
         ~edges:[ depends_on r1; depends_on r2 ]
     | Single_end_sample (dataset, single) ->
       let r1 = gunzip_concat ~read:(`R1 dataset) single in
@@ -387,6 +390,8 @@ let rec compile_aligner_step
       workflow_node (fastq_reads ~host:Machine.(as_host machine)
                        r1#product#path None)
         ~edges:[ depends_on r1 ]
+        ~name:(sprintf "single-end %s"
+                 (Filename.basename r1#product#path))
   in
   match t with
   | Bam_sample (name, bam_target) -> bam_target

--- a/src/lib/biokepi_pipeline.ml
+++ b/src/lib/biokepi_pipeline.ml
@@ -30,7 +30,7 @@ type json = Yojson.Basic.json
 type fastq_gz = Fastq_gz
 type fastq = Fastq
 type fastq_sample = Fastq_sample
-type bam = Bam
+type bam = KEDSL.bam_file KEDSL.workflow_node
 type bam_pair = Bam_pair
 type vcf = Vcf
 
@@ -46,8 +46,8 @@ module Somatic_variant_caller = struct
     make_target:
       reference_build: [`B37 | `B38 | `hg19 | `hg18 | `B37decoy ] -> 
       run_with:Biokepi_run_environment.Machine.t ->
-      normal:KEDSL.file_workflow ->
-      tumor:KEDSL.file_workflow ->
+      normal: bam ->
+      tumor: bam ->
       result_prefix: string ->
       processors: int ->
       unit ->
@@ -63,7 +63,7 @@ module Germline_variant_caller = struct
     make_target:
       reference_build: [`B37 | `B38 | `hg19 | `hg18 | `B37decoy ] -> 
       run_with:Biokepi_run_environment.Machine.t ->
-      input_bam:KEDSL.file_workflow ->
+      input_bam: bam ->
       result_prefix: string ->
       processors: int ->
       unit ->
@@ -75,7 +75,7 @@ type _ t =
   | Fastq_gz: File.t -> fastq_gz  t
   | Fastq: File.t -> fastq  t
   (* | List: 'a t list -> 'a list t *)
-  | Bam_sample: string * File.t -> bam t
+  | Bam_sample: string * bam -> bam t
   | Bam_to_fastq: [ `Single | `Paired ] * bam t -> fastq_sample t
   | Paired_end_sample: string * fastq  t * fastq  t -> fastq_sample  t
   | Single_end_sample: string * fastq  t -> fastq_sample  t

--- a/src/lib/biokepi_reference_genome.ml
+++ b/src/lib/biokepi_reference_genome.ml
@@ -6,17 +6,20 @@ open Biokepi_common
 *)
 type t = {
   name: string;
-  location: Ketrew.EDSL.user_target;
-  cosmic:  Ketrew.EDSL.user_target option;
-  dbsnp:  Ketrew.EDSL.user_target option;
+  location: KEDSL.file_workflow;
+  cosmic:  KEDSL.file_workflow option;
+  dbsnp:  KEDSL.file_workflow option;
 }
 let create ?cosmic ?dbsnp name location =
   {name; location; cosmic; dbsnp}
 
 let on_host ~host ?cosmic ?dbsnp name path =
-  let location = Ketrew.EDSL.file_target ~host path in
-  let cosmic = Option.map ~f:(Ketrew.EDSL.file_target ~host) cosmic in
-  let dbsnp = Option.map ~f:(Ketrew.EDSL.file_target ~host) dbsnp in
+  let open KEDSL in
+  let location =
+    workflow_node (single_file ~host path) in
+  let optional = Option.map ~f:(fun p -> workflow_node (single_file ~host p)) in
+  let cosmic = optional cosmic in
+  let dbsnp = optional dbsnp in
   create ?cosmic ?dbsnp name location
 
 
@@ -32,7 +35,7 @@ let dbsnp_path_exn t =
   let trgt = Option.value_exn ~msg t.dbsnp in
   trgt#product#path
 
-let fasta: t -> Ketrew.EDSL.user_target = fun t -> t.location
+let fasta: t -> KEDSL.file_workflow = fun t -> t.location
 let cosmic_exn t =
   Option.value_exn ~msg:(sprintf "%s: no COSMIC" t.name) t.cosmic
 let dbsnp_exn t =

--- a/src/lib/biokepi_reference_genome.ml
+++ b/src/lib/biokepi_reference_genome.ml
@@ -16,10 +16,13 @@ let create ?cosmic ?dbsnp name location =
 let on_host ~host ?cosmic ?dbsnp name path =
   let open KEDSL in
   let location =
-    workflow_node (single_file ~host path) in
-  let optional = Option.map ~f:(fun p -> workflow_node (single_file ~host p)) in
-  let cosmic = optional cosmic in
-  let dbsnp = optional dbsnp in
+    workflow_node
+      ~name:(sprintf "Fasta: %s" Filename.(basename path))
+      (single_file ~host path) in
+  let optional name =
+    Option.map ~f:(fun p -> workflow_node ~name (single_file ~host p)) in
+  let cosmic = optional "Cosmic DB" cosmic in
+  let dbsnp = optional "DBSNP" dbsnp in
   create ?cosmic ?dbsnp name location
 
 

--- a/src/lib/biokepi_reference_genome.mli
+++ b/src/lib/biokepi_reference_genome.mli
@@ -22,9 +22,9 @@ open Biokepi_common
 
 type t = {
   name : string;
-  location : Ketrew.EDSL.user_target;
-  cosmic :  Ketrew.EDSL.user_target option;
-  dbsnp :  Ketrew.EDSL.user_target option;
+  location : KEDSL.file_workflow;
+  cosmic :  KEDSL.file_workflow option;
+  dbsnp :  KEDSL.file_workflow option;
 }
 (** A reference genome has a name (for display/matching) and a
      cluster-dependent path.
@@ -34,13 +34,13 @@ type t = {
 (** {3 Creation } *)
 
 val create :
-  ?cosmic:Ketrew.EDSL.user_target ->
-  ?dbsnp:Ketrew.EDSL.user_target ->
-  string -> Ketrew.EDSL.user_target -> t
+  ?cosmic:KEDSL.file_workflow ->
+  ?dbsnp:KEDSL.file_workflow ->
+  string -> KEDSL.file_workflow -> t
 (** Build a [Reference_genome.t] record. *)
 
 val on_host :
-  host:Ketrew.EDSL.Host.t ->
+  host:KEDSL.Host.t ->
   ?cosmic:string -> ?dbsnp:string -> string -> string -> t
 (** Create a [Reference_genome.t] by applying [Ketrew.EDSL.file_target] for
     each path on a given [host]. *)
@@ -54,6 +54,6 @@ val dbsnp_path_exn : t -> string
  
 (** {3 Targets} *)
 
-val fasta: t -> Ketrew.EDSL.user_target
-val cosmic_exn: t -> Ketrew.EDSL.user_target
-val dbsnp_exn: t -> Ketrew.EDSL.user_target
+val fasta: t -> KEDSL.file_workflow
+val cosmic_exn: t -> KEDSL.file_workflow
+val dbsnp_exn: t -> KEDSL.file_workflow

--- a/src/lib/biokepi_run_environment.ml
+++ b/src/lib/biokepi_run_environment.ml
@@ -176,6 +176,7 @@ module Tool_providers = struct
                  ~f:sh ~default:(shf "cp %s ../" tool_name)) in
     let tar_option = if Filename.check_suffix url "bz2" then "j" else "z" in
     workflow_node
+      ~name:(sprintf "Install %s" tool_name)
       (single_file ~host
          (Option.value witness ~default:(install_path // tool_name)))
       ~edges:[
@@ -269,6 +270,7 @@ module Tool_providers = struct
     let binary = install_path // "somaticsniper" in
     let ensure =
       workflow_node (single_file binary ~host)
+        ~name:(sprintf "Install somaticsniper")
         ~edges:[depends_on binary_got]
         ~make:(daemonize ~using:`Python_daemon ~host
                  Program.(shf "mv %s %s"
@@ -285,6 +287,7 @@ module Tool_providers = struct
     let jar = install_path // "VarScan.v2.3.5.jar" in
     let ensure =
       workflow_node (single_file jar ~host)
+        ~name:"Install varscan"
         ~make:(daemonize ~host ~using:`Python_daemon
                  Program.(
                    exec ["mkdir"; "-p"; install_path]
@@ -302,6 +305,7 @@ module Tool_providers = struct
     let jar = install_path // "picard-tools-1.127" // "picard.jar" in
     let ensure =
       workflow_node (single_file jar ~host)
+        ~name:"Install picard"
         ~make:(daemonize ~host ~using:`Python_daemon
                  Program.(
                    exec ["mkdir"; "-p"; install_path]
@@ -370,6 +374,7 @@ module Tool_providers = struct
     let ensure =
       (* C.f. ftp://ftp.illumina.com/v1-branch/v1.0.14/README *)
       workflow_node (single_file witness ~host)
+        ~name:"Build/install Strelka"
         ~make:(daemonize ~host ~using:`Python_daemon
                  Program.(
                    exec ["mkdir"; "-p"; install_path]
@@ -391,6 +396,7 @@ module Tool_providers = struct
     let jar = install_path // "Virmid-1.1.1" // "Virmid.jar" in
     let ensure =
       workflow_node (single_file jar ~host)
+        ~name:"Build/install Virmid"
         ~make:(daemonize ~host ~using:`Python_daemon
                  Program.(
                    exec ["mkdir"; "-p"; install_path]

--- a/src/lib/biokepi_run_environment.ml
+++ b/src/lib/biokepi_run_environment.ml
@@ -462,7 +462,7 @@ module Data_providers = struct
     let open KEDSL in
     let is_gz = Filename.check_suffix url ".gz" in
     if is_gz then (
-      let name = "gunzip-" ^ (destination ^ ".gz") in
+      let name = "gunzip-" ^ Filename.basename (destination ^ ".gz") in
       let wgot = wget ~host ~run_program url (destination ^ ".gz") in
       workflow_node
         (single_file destination ~host)

--- a/src/lib/biokepi_somatic_targets.ml
+++ b/src/lib/biokepi_somatic_targets.ml
@@ -26,8 +26,12 @@ module Mutect = struct
       let dbsnp = Reference_genome.dbsnp_exn reference in
       let fasta_dot_fai = Samtools.faidx ~run_with fasta in
       let sequence_dict = Picard.create_dict ~run_with fasta in
-      let sorted_normal = Samtools.sort_bam ~processors:2 ~run_with ~by:`Coordinate normal in
-      let sorted_tumor = Samtools.sort_bam ~processors:2 ~run_with ~by:`Coordinate tumor in
+      let sorted_normal =
+        Samtools.sort_bam_if_necessary
+          ~processors:2 ~run_with ~by:`Coordinate normal in
+      let sorted_tumor =
+        Samtools.sort_bam_if_necessary
+          ~processors:2 ~run_with ~by:`Coordinate tumor in
       let run_mutect =
         let name = sprintf "%s" (Filename.basename output_file) in
         let make =
@@ -102,8 +106,10 @@ module Somaticsniper = struct
       Machine.get_reference_genome run_with reference_build |> Reference_genome.fasta in
     let output_file = result_file "-snvs.vcf" in
     let run_path = Filename.dirname output_file in
-    let sorted_normal = Samtools.sort_bam ~run_with ~by:`Coordinate normal in
-    let sorted_tumor = Samtools.sort_bam ~run_with ~by:`Coordinate tumor in
+    let sorted_normal =
+      Samtools.sort_bam_if_necessary ~run_with ~by:`Coordinate normal in
+    let sorted_tumor =
+      Samtools.sort_bam_if_necessary ~run_with ~by:`Coordinate tumor in
     let make =
       Machine.run_program run_with
         ~name ~processors:1 Program.(
@@ -383,8 +389,12 @@ The usage is:
       Machine.get_reference_genome run_with reference_build |> Reference_genome.fasta in
     let strelka_tool = Machine.get_tool run_with Tool.Default.strelka in
     let gatk_tool = Machine.get_tool run_with Tool.Default.gatk in
-    let sorted_normal = Samtools.sort_bam ~run_with ~processors ~by:`Coordinate normal in
-    let sorted_tumor = Samtools.sort_bam ~run_with ~processors ~by:`Coordinate tumor in
+    let sorted_normal =
+      Samtools.sort_bam_if_necessary
+        ~run_with ~processors ~by:`Coordinate normal in
+    let sorted_tumor =
+      Samtools.sort_bam_if_necessary
+        ~run_with ~processors ~by:`Coordinate tumor in
     let working_dir = Filename.(dirname result_prefix) in
     let make =
       Machine.run_program run_with ~name ~processors

--- a/src/lib/biokepi_target_library.ml
+++ b/src/lib/biokepi_target_library.ml
@@ -39,7 +39,7 @@ module Bwa = struct
     let name =
       sprintf "bwa-index-%s" (Filename.basename reference_fasta#product#path) in
     let result = sprintf "%s.bwt" reference_fasta#product#path in
-    workflow_node
+    workflow_node ~name
       (single_file ~host:(Machine.(as_host run_with)) result)
       ~edges:[
         on_failure_activate (Remove.file ~run_with result);

--- a/src/lib/biokepi_util_targets.ml
+++ b/src/lib/biokepi_util_targets.ml
@@ -194,7 +194,7 @@ module Picard = struct
                  metrics_path) in
     let make = Machine.run_program run_with program in
     let host = Machine.(as_host run_with) in
-    workflow_node (bam_file output_bam ~host)
+    workflow_node (bam_file ~sorting:`Coordinate output_bam ~host)
       ~name:(sprintf "picard-markdups-%s"
                Filename.(basename input_bam#product#path))
       ~make
@@ -317,7 +317,8 @@ module Gatk = struct
         ) in
     let sequence_dict = Picard.create_dict ~run_with fasta in
     workflow_node ~name
-      (bam_file output_bam ~host:Machine.(as_host run_with))
+      (bam_file ~sorting:`Coordinate
+         output_bam ~host:Machine.(as_host run_with))
       ~make
       ~edges:[
         depends_on Tool.(ensure gatk);
@@ -381,7 +382,8 @@ module Gatk = struct
           ]
         ) in
     workflow_node ~name
-      (bam_file output_bam ~host:Machine.(as_host run_with))
+      (bam_file output_bam
+         ~sorting:`Coordinate ~host:Machine.(as_host run_with))
       ~make
       ~edges:[
         depends_on Tool.(ensure gatk); depends_on fasta; depends_on db_snp;


### PR DESCRIPTION

This is an experiment to create a stricter EDSL on top of Ketrew; the changes
imply a hige refactoring that does not change any semantics.
It's a bit what was there: https://github.com/hammerlab/ketrew/pull/182 so it may be a staging area before pushing upstream,

Now the `bantofastq` workflow-node “returns” a proper FASTQ pair-of-files or single-file.

This in the same time updtates to the latests version of Ketrew's API.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/45)
<!-- Reviewable:end -->
