### PR TITLE
Specify the tmpdir for java as well for picard

### DIFF
--- a/src/lib/picard.ml
+++ b/src/lib/picard.ml
@@ -50,7 +50,7 @@ module Mark_duplicates_settings = struct
              MAX_SEQUENCES_FOR_DISK_READ_ENDS_MAP=%d \
              MAX_FILE_HANDLES_FOR_READ_ENDS_MAP=%d \
              SORTING_COLLECTION_SIZE_RATIO=%f \
-             java %s "
+             java %s -Djava.io.tmpdir=%s "
       t.tmpdir
       t.max_sequences_for_disk_read_ends_map
       t.max_file_handles_for_read_ends_map
@@ -58,6 +58,7 @@ module Mark_duplicates_settings = struct
       (match t.mem_param with
       | None  -> ""
       | Some some -> sprintf "-Xmx%s" some)
+      t.tmpdir
 
 end
 let mark_duplicates


### PR DESCRIPTION
Looks like it is a commonly known problem that Picard ignores the TMP_DIR (or it's reset at somepoint) and providing the java tmpdir is more effective

See:
https://bitbucket.org/galaxy/galaxy-central/pull-request/28/specify-java-temp-directory-for-picard/diff
http://sourceforge.net/p/samtools/mailman/message/27300266/
http://dev.list.galaxyproject.org/incorrect-tmp-dir-handling-in-picard-AddOrReplaceReadGroups-td4529840.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/51)
<!-- Reviewable:end -->
