### PR TITLE
Name bam pair after tumor file

### DIFF
--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -289,9 +289,9 @@ let rec to_file_prefix:
     | Gatk_bqsr bam ->
       sprintf "%s-bqsr" (to_file_prefix ?is ?read bam)
     | Picard_mark_duplicates (_, bam) ->
-      (* The settings, for now, do not impact the resul.t *)
+      (* The settings, for now, do not impact the result *)
       sprintf "%s-dedup" (to_file_prefix ?is ?read bam)
-    | Bam_pair (nor, tum) -> to_file_prefix ?is:None nor
+    | Bam_pair (nor, tum) -> to_file_prefix ?is:None tum
     | Somatic_variant_caller (vc, bp) ->
       let prev = to_file_prefix bp in
       sprintf "%s-%s-%s" prev


### PR DESCRIPTION
- There can be multiple somatic variant calling runs with the same normal file, but different tumor files.  Naming the run after the normal file would create a file name collision.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/54)
<!-- Reviewable:end -->
