### PR TITLE
Remove equivalence from single end

### DIFF
--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -156,7 +156,7 @@ module KEDSL = struct
       method is_done =
         Some (match r2_file_opt with
           | Some r2 -> `And [r1_file#exists; r2#exists]
-          | None -> r1_file#exists)
+          | None -> `And [r1_file#exists; r1_file#exists;])
     end
 
   type bam_file = <

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -411,6 +411,7 @@ let rec compile_aligner_step
       let open KEDSL in
       workflow_node (fastq_reads ~host:Machine.(as_host machine)
                        r1#product#path None)
+        ~equivalence:`None
         ~edges:[ depends_on r1 ]
         ~name:(sprintf "single-end %s"
                  (Filename.basename r1#product#path))


### PR DESCRIPTION
Not sure if you want to merge this @smondet or if you will find a better solution, but filed the PR to record the problem and possible fix.

The single-end workflow node ends up in a loop by having a dependency with the same success condition.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/60)
<!-- Reviewable:end -->
