### PR TITLE
Fix STAR output path

### DIFF
--- a/src/lib/star.ml
+++ b/src/lib/star.ml
@@ -58,7 +58,8 @@ let align
   let star_index = index ~reference_build ~run_with ~processors in
   let reference_dir = (Filename.dirname reference_fasta#product#path) in
   let star_index_dir = sprintf "%s/star-index/" reference_dir in
-  let result = sprintf "%s.sortedByCoord.out.bam" result_prefix in
+  (* STAR appends Aligned.sortedByCoord.out.bam to the filename *)
+  let result = sprintf "%sAligned.sortedByCoord.out.bam" result_prefix in
   let r1_path, r2_path_opt = fastq#product#paths in
   let name = sprintf "star-rna-align-%s" (Filename.basename r1_path) in
   let star_base_command = sprintf 


### PR DESCRIPTION
This actually undoes something from #65 where the output file name was change.  Part of that filename comes automatically from STAR, so I reverted that and added a comma.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/66)
<!-- Reviewable:end -->
