### PR TITLE
add filter_reads_with_N_cigar to GATK HC

### DIFF
--- a/src/lib/gatk.ml
+++ b/src/lib/gatk.ml
@@ -147,6 +147,7 @@ let haplotype_caller ~run_with ~reference_build ~input_bam ~result_prefix how  =
               "-I"; sorted_bam#product#path;
               "-R"; reference_fasta#product#path;
               "-o"; output_vcf;
+              "--filter_reads_with_N_cigar";
             ]
           )
       in


### PR DESCRIPTION
GATK HaplotypeCaller fails on DNA BAM files with CIGAR N - this flag skips those lines.  It would be nice to restrict this to BAM files that only have `~contains \`DNA` is that possible?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/67)
<!-- Reviewable:end -->
