### PR TITLE
Add documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,23 +14,26 @@ build:
 	    mv _build/src/test/main.native test_biokepi && \
 	    mv _build/src/app/main.native biokepi-demo
 
-apidoc:
-	mkdir -p _apidoc && \
-	ocamlfind ocamldoc -html -d _apidoc/ -package ketrew  \
-	    -thread  -charset UTF-8 -t "Biokepi API" -keep-code -colorize-code \
-	    -sort \
-	    -I _build/src/lib/ \
-	    src/lib/*.mli src/lib/*.ml
+doc:
+	ocaml setup.ml -doc
 
-doc: apidoc build
-	INPUT=src/doc/ \
-	    INDEX=README.md \
-	    TITLE_PREFIX="Biokepi: " \
-	    OUTPUT_DIR=_doc \
-	    API=_apidoc \
-	    CATCH_MODULE_PATHS='^(Biokepi[A-Z_a-z]+):', \
-	    TITLE_SUBSTITUTIONS="main.ml:Literate Tests" \
-	    oredoc
+#apidoc:
+#	mkdir -p _apidoc && \
+#	ocamlfind ocamldoc -html -d _apidoc/ -package ketrew  \
+#	    -thread  -charset UTF-8 -t "Biokepi API" -keep-code -colorize-code \
+#	    -sort \
+#	    -I _build/src/lib/ \
+#	    src/lib/*.mli src/lib/*.ml
+
+#doc: apidoc build
+#	INPUT=src/doc/ \
+#	    INDEX=README.md \
+#	    TITLE_PREFIX="Biokepi: " \
+#	    OUTPUT_DIR=_doc \
+#	    API=_apidoc \
+#	    CATCH_MODULE_PATHS='^(Biokepi[A-Z_a-z]+):', \
+#	    TITLE_SUBSTITUTIONS="main.ml:Literate Tests" \
+#	    oredoc
 
 clean:
 	rm -fr _build test_biokepi biokepi-demo

--- a/_oasis
+++ b/_oasis
@@ -52,3 +52,10 @@ Executable "biokepi-demo"
   CompiledObject: best
   BuildDepends: biokepi, threads
   MainIs:     main.ml
+
+Document biokepi
+  Title:                API reference for Biokepi
+  Type:                 ocamlbuild (0.4)
+  BuildTools:           ocamlbuild, ocamldoc
+  XOCamlbuildPath:      src/lib
+  XOCamlbuildLibraries: biokepi

--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -14,24 +14,31 @@
 (*  permissions and limitations under the License.                        *)
 (**************************************************************************)
 
-(** [Pervasives] module for the library. *)
+(** Module opened by default (like
+{{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Pervasives.html}Pervasives})
+for our library. *)
 
+(** A {{:http://seb.mondet.org/software/nonstd/index.html}Non-standard mini
+library}. *)
 include Nonstd
+
+(** A String module with more capabilities *)
 module String = struct
   include Sosa.Native_string
 end
 
 let (//) = Filename.concat
-(** A very standard operator. *)
+(** [path // filename] will concat [filename] to the end of [path]. *)
 
 let dbg fmt = ksprintf (eprintf "biokepi-debug: %s\n%!") fmt
+(** A consistent debugging mechanism. *)
 
 let failwithf fmt = ksprintf failwith fmt
+(** A formatted {!failwith} *)
 
 module Unique_id = struct
   include Ketrew_pure.Internal_pervasives.Unique_id
 end
-
 
 (**
 

--- a/src/lib/muse.ml
+++ b/src/lib/muse.ml
@@ -1,4 +1,4 @@
-(** Workflow-nodes to run {:http://bioinformatics.mdanderson.org/main/MuSE{MuSE}}. *)
+(** Workflow-nodes to run {{:http://bioinformatics.mdanderson.org/main/MuSE}MuSE}. *)
 
 open Common
 open Run_environment


### PR DESCRIPTION
I took out the call to `oredoc`, happy to add that back when `oredoc` is easier to access. This should address #72 as there is now `gh-pages` branch being [served](https://github.com/hammerlab/biokepi). But I think we should file separate issues for improving documentation.