### PR TITLE
Make COSMIC optional for Mutect

### DIFF
--- a/src/lib/mutect.ml
+++ b/src/lib/mutect.ml
@@ -4,11 +4,16 @@ open Workflow_utilities
 
 module Configuration = struct
 
-  type t = { name: string; parameters: (string * string) list; }
+  type t = {
+    name: string;
+    with_cosmic: bool;
+    parameters: (string * string) list;
+  }
 
-  let to_json {name; parameters}: Yojson.Basic.json =
+  let to_json {name; with_cosmic; parameters}: Yojson.Basic.json =
     `Assoc [
       "name", `String name;
+      "with-cosmic", `Bool with_cosmic;
       "parameters",
       `Assoc (List.map parameters ~f:(fun (a, b) -> a, `String b));
     ]
@@ -16,7 +21,10 @@ module Configuration = struct
     List.concat_map parameters ~f:(fun (a,b) -> [a; b])
 
   let default =
-    {name = "default"; parameters = []}
+    {name = "default"; with_cosmic = true; parameters = []}
+  let default_without_cosmic =
+    {name = "default_without_cosmic"; with_cosmic = false; parameters = []}
+
 
 end
 
@@ -36,7 +44,10 @@ let run ?(reference_build=`B37)
     let run_path = Filename.dirname output_file in
     let reference = Machine.get_reference_genome run_with reference_build in
     let fasta = Reference_genome.fasta reference in
-    let cosmic = Reference_genome.cosmic_exn reference in
+    let cosmic =
+      match configuration.Configuration.with_cosmic with
+      | true -> Some (Reference_genome.cosmic_exn reference)
+      | false -> None in
     let dbsnp = Reference_genome.dbsnp_exn reference in
     let fasta_dot_fai = Samtools.faidx ~run_with fasta in
     let sequence_dict = Picard.create_dict ~run_with fasta in
@@ -48,40 +59,45 @@ let run ?(reference_build=`B37)
         ~processors:2 ~run_with ~by:`Coordinate tumor in
     let run_mutect =
       let name = sprintf "%s" (Filename.basename output_file) in
+      let cosmic_option =
+        Option.value_map ~default:"" cosmic ~f:(fun node ->
+            sprintf "--cosmic %s" (Filename.quote node#product#path)) in 
       let make =
         Machine.run_program run_with ~name ~processors:2 Program.(
             Tool.(init mutect)
             && shf "mkdir -p %s" run_path
             && shf "cd %s" run_path
             && sh ("java -Xmx2g -jar $mutect_HOME/muTect-*.jar --analysis_type MuTect " ^
-                     (String.concat ~sep:" " ([
-                       "--reference_sequence"; fasta#product#path;
-                       "--cosmic"; cosmic#product#path;
-                       "--dbsnp"; dbsnp#product#path;
-                       ""; intervals_option;
-                       "--input_file:normal"; sorted_normal#product#path;
-                       "--input_file:tumor"; sorted_tumor#product#path;
-                       "--out"; dot_out_file;
-                       "--vcf"; output_file;
-                       "--coverage_file"; coverage_file;
+                   (String.concat ~sep:" " ([
+                        "--reference_sequence"; fasta#product#path;
+                        cosmic_option;
+                        "--dbsnp"; dbsnp#product#path;
+                        ""; intervals_option;
+                        "--input_file:normal"; sorted_normal#product#path;
+                        "--input_file:tumor"; sorted_tumor#product#path;
+                        "--out"; dot_out_file;
+                        "--vcf"; output_file;
+                        "--coverage_file"; coverage_file;
                       ] @ Configuration.render configuration))))
       in
+      let edges =
+        Option.value_map cosmic ~default:[] ~f:(fun n -> [depends_on n])
+        @ add_edges
+        @ [
+          depends_on Tool.(ensure mutect);
+          depends_on sorted_normal;
+          depends_on sorted_tumor;
+          depends_on fasta;
+          depends_on dbsnp;
+          depends_on fasta_dot_fai;
+          depends_on sequence_dict;
+          depends_on (Samtools.index_to_bai ~run_with sorted_normal);
+          depends_on (Samtools.index_to_bai ~run_with sorted_tumor);
+          on_failure_activate (Remove.file ~run_with output_file);
+        ] in
       workflow_node ~name ~make
         (single_file output_file ~host:Machine.(as_host run_with))
-        ~tags:[Target_tags.variant_caller]
-        ~edges:(add_edges @ [
-            depends_on Tool.(ensure mutect);
-            depends_on sorted_normal;
-            depends_on sorted_tumor;
-            depends_on fasta;
-            depends_on cosmic;
-            depends_on dbsnp;
-            depends_on fasta_dot_fai;
-            depends_on sequence_dict;
-            depends_on (Samtools.index_to_bai ~run_with sorted_normal);
-            depends_on (Samtools.index_to_bai ~run_with sorted_tumor);
-            on_failure_activate (Remove.file ~run_with output_file);
-          ])
+        ~tags:[Target_tags.variant_caller] ~edges
     in
     run_mutect
   in


### PR DESCRIPTION
This fixes #89, it allows one to choose whether to depend on the COSMIC
DB from the `Configuration.t`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/107)
<!-- Reviewable:end -->
