### PR TITLE
Remove `~by` argument of `sort_bam_if_necessary`

### DIFF
--- a/src/lib/samtools.ml
+++ b/src/lib/samtools.ml
@@ -133,7 +133,12 @@ let sort_bam_no_check ~(run_with:Machine.t) ?(processors=1) ~by input_bam =
     ~name:(sprintf "Samtools-sort %s"
              Filename.(basename input_bam#product#path))
 
-let sort_bam_if_necessary ~(run_with:Machine.t) ?(processors=1) ~by input_bam =
+(**
+   Uses ["samtools sort"] by coordinate if the [input_bam] is not tagged as
+   “sorted by coordinate.”
+   If it is indeed sorted the function returns the [input_bam] node as is.
+*)
+let sort_bam_if_necessary ~(run_with:Machine.t) ?(processors=1) input_bam =
   match input_bam#product#sorting with
   | Some `Coordinate -> input_bam
   | other ->


### PR DESCRIPTION
This fixes #130, if one day we need to sort by something else than
coordinate we can expand the functionality.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/132)
<!-- Reviewable:end -->
