### PR TITLE
Indel-realignment on multiple bams

### DIFF
--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -115,6 +115,14 @@ module KEDSL = struct
         )
     end
 
+  let expolode_bam_list_node (bln : bam_list workflow_node) =
+    List.map bln#product#bams ~f:(fun bam ->
+        workflow_node bam
+          ~name:(Filename.basename bam#path)
+          ~tags:["expolode_bam_list_node"]
+          ~edges:[depends_on bln]
+          ~equivalence:`None)
+
   (* this may be overkill: *)
   type _ bam_or_bams =
     | Single_bam: bam_file workflow_node -> bam_file workflow_node bam_or_bams

--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -99,6 +99,27 @@ module KEDSL = struct
       method content_type = contains
     end
 
+  type bam_list = <
+    is_done:  Ketrew_pure.Target.Condition.t option;
+    bams: bam_file list;
+  >
+  let bam_list (bams : bam_file list) : bam_list =
+    object 
+      method bams = bams
+      method is_done =
+        Some (
+          `And (List.map bams
+                  ~f:(fun b ->
+                      b#is_done
+                      |> Option.value_exn ~msg:"Bams should have a Condition.t"))
+        )
+    end
+
+  (* this may be overkill: *)
+  type _ bam_or_bams =
+    | Single_bam: bam_file workflow_node -> bam_file workflow_node bam_or_bams
+    | Bam_workflow_list: bam_file workflow_node list -> bam_list workflow_node bam_or_bams
+
   let submit w = Ketrew.Client.submit_workflow w
 
 end

--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -115,7 +115,7 @@ module KEDSL = struct
         )
     end
 
-  let expolode_bam_list_node (bln : bam_list workflow_node) =
+  let explode_bam_list_node (bln : bam_list workflow_node) =
     List.map bln#product#bams ~f:(fun bam ->
         workflow_node bam
           ~name:(Filename.basename bam#path)

--- a/src/lib/gatk.ml
+++ b/src/lib/gatk.ml
@@ -153,7 +153,7 @@ let indel_realigner :
       (* we make this file “unique” with an MD5 sum of the input paths *)
       |> Digest.string |> Digest.to_hex in
     let output_suffix =
-      sprintf "-target-%s-%dx-%s"
+      sprintf "_target-%s-%dx-%s"
         target_config.Configuration.Indel_realigner.name
         (List.length more_input_bams + 1)
         (if more_input_bams = [] then "" else "-" ^ digest_of_input)

--- a/src/lib/gatk.ml
+++ b/src/lib/gatk.ml
@@ -139,7 +139,7 @@ let indel_realigner :
         ~f:(Samtools.sort_bam_if_necessary
               ~run_with ~processors ~by:`Coordinate) in
     let name = 
-      sprintf "gatk-indelralign-%dx-%s" 
+      sprintf "gatk-indelrealign-%dx-%s" 
         (List.length more_input_bams + 1)
         (Filename.basename input_sorted_bam_1#product#path) in
     let gatk = Machine.get_tool run_with Tool.Default.gatk in

--- a/src/lib/gatk.ml
+++ b/src/lib/gatk.ml
@@ -93,67 +93,149 @@ module Configuration = struct
 
 
 end
+
   (*
      For now we have the two steps in the same target but this could
      be split in two.
      c.f. https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_indels_IndelRealigner.php
-  *)
-let indel_realigner
-    ?(compress=false)
-    ~configuration
-    ~reference_build
-    ~processors
-    ~run_with input_bam ~output_bam =
-  let open KEDSL in
-  let indel_config, target_config = configuration in
-  let name = sprintf "gatk-%s" (Filename.basename output_bam) in
-  let gatk = Machine.get_tool run_with Tool.Default.gatk in
-  let reference_genome = Machine.get_reference_genome run_with reference_build in
-  let fasta = Reference_genome.fasta reference_genome in
-  let intervals_file =
-    Filename.chop_suffix input_bam#product#path ".bam" ^ "-target.intervals"
-  in
-  let sorted_bam =
-    Samtools.sort_bam_if_necessary
-      ~run_with ~processors ~by:`Coordinate input_bam in
-  let make =
-    Machine.run_program run_with ~name
-      Program.(
-        Tool.(init gatk)
-        && sh ("java -jar $GATK_JAR -T RealignerTargetCreator " ^
-               (String.concat ~sep:" " ([
-                    "-R"; fasta#product#path;
-                    "-I"; sorted_bam#product#path;
-                    "-o"; intervals_file;
-                    "-nt"; Int.to_string processors
-                  ] @ Configuration.Realigner_target_creator.render target_config)))
-        && sh ("java -jar $GATK_JAR -T IndelRealigner"
-               ^ (if compress then " " else " -compress 0 ")
-               ^ (String.concat ~sep:" " ([
-                   "-R"; fasta#product#path;
-                   "-I"; sorted_bam#product#path;
-                   "-o"; output_bam;
-                   "-targetIntervals"; intervals_file;
-                 ] @ Configuration.Indel_realigner.render indel_config))))
-  in
-  let sequence_dict = Picard.create_dict ~run_with fasta in
-  workflow_node ~name
-    (bam_file ~sorting:`Coordinate
-       output_bam ~host:Machine.(as_host run_with))
-    ~make
-    ~edges:[
-      depends_on Tool.(ensure gatk);
-      depends_on fasta;
-      depends_on sorted_bam;
-      depends_on (Samtools.index_to_bai ~run_with sorted_bam);
-      (* RealignerTargetCreator wants the `.fai`: *)
-      depends_on (Samtools.faidx ~run_with fasta);
-      depends_on input_bam;
-      depends_on sequence_dict;
-      on_failure_activate (Remove.file ~run_with output_bam);
-      on_failure_activate (Remove.file ~run_with intervals_file);
-    ]
 
+     We want to be able to run the indel-realigner on mutliple bams, so we
+     cannot use the usual `~result_prefix` argument:
+     See the documentation for the `--nWayOut` option:
+     https://www.broadinstitute.org/gatk/guide/tooldocs/org_broadinstitute_gatk_tools_walkers_indels_IndelRealigner.php#--nWayOut
+     See also 
+     http://gatkforums.broadinstitute.org/gatk/discussion/5588/best-practice-for-multi-sample-non-human-indel-realignment
+
+     On top of that we the GADT `_ KEDSL.bam_or_bams` to return have 2 possible
+     return types:
+     bam_file workflow_node or bam_list workflow_node
+  *)
+open Configuration
+let indel_realigner :
+  type a.
+  ?compress:bool ->
+  configuration:(Indel_realigner.t * Realigner_target_creator.t) ->
+  reference_build:string ->
+  processors:int ->
+  run_with:Run_environment.Machine.t ->
+  a KEDSL.bam_or_bams ->
+  a =
+  fun ?(compress=false)
+    ~configuration ~reference_build ~processors ~run_with input_bam_or_bams ->
+    let open KEDSL in
+    let input_bam_1, more_input_bams = (* this an at-least-length-1 list :)  *)
+      match input_bam_or_bams with
+      | Single_bam bam -> bam, []
+      | Bam_workflow_list [] -> 
+        failwithf "Empty bam-list in Gatk.indel_realigner`"
+      | Bam_workflow_list (one :: more) -> (one, more)
+    in
+    let indel_config, target_config = configuration in
+    let input_sorted_bam_1 =
+      Samtools.sort_bam_if_necessary
+        ~run_with ~processors ~by:`Coordinate input_bam_1 in
+    let more_input_sorted_bams =
+      List.map more_input_bams
+        ~f:(Samtools.sort_bam_if_necessary
+              ~run_with ~processors ~by:`Coordinate) in
+    let name = 
+      sprintf "gatk-indelralign-%dx-%s" 
+        (List.length more_input_bams + 1)
+        (Filename.basename input_sorted_bam_1#product#path) in
+    let gatk = Machine.get_tool run_with Tool.Default.gatk in
+    let reference_genome =
+      Machine.get_reference_genome run_with reference_build in
+    let fasta = Reference_genome.fasta reference_genome in
+    let digest_of_input =
+      List.map (input_sorted_bam_1 :: more_input_sorted_bams)
+        ~f:(fun o -> o#product#path)
+      |> String.concat ~sep:"" 
+      (* we make this file “unique” with an MD5 sum of the input paths *)
+      |> Digest.string |> Digest.to_hex in
+    let output_suffix =
+      sprintf "-target-%s-%dx-%s"
+        target_config.Configuration.Indel_realigner.name
+        (List.length more_input_bams + 1)
+        (if more_input_bams = [] then "" else "-" ^ digest_of_input)
+    in
+    let intervals_file =
+      Filename.chop_suffix input_sorted_bam_1#product#path ".bam" 
+      ^ output_suffix ^ ".intervals" in
+    let make =
+      let target_creation_args =
+        [
+          "-R"; Filename.quote fasta#product#path;
+          "-I"; Filename.quote input_sorted_bam_1#product#path;
+          "-o"; Filename.quote intervals_file;
+          "-nt"; Int.to_string processors
+        ]
+        @ Realigner_target_creator.render target_config
+        @ List.concat_map more_input_bams
+          ~f:(fun bam -> ["-I"; Filename.quote bam#product#path])
+      in
+      let indel_real_args =
+        [ "-R"; fasta#product#path;
+          "-I"; input_sorted_bam_1#product#path;
+          "-targetIntervals"; intervals_file;
+        ] @ Indel_realigner.render indel_config @
+        begin match more_input_bams with
+        | [] ->
+          ["-o";
+           Filename.chop_extension
+             input_sorted_bam_1#product#path ^ output_suffix ^ ".bam" ;]
+        | more ->
+          List.concat_map more
+            ~f:(fun b -> ["-I"; Filename.quote b#product#path])
+          @ ["--nWayOut"; output_suffix ^ ".bam"]
+        end
+      in
+      Machine.run_program run_with ~name
+        Program.(
+          Tool.(init gatk)
+          && shf "java -jar $GATK_JAR -T RealignerTargetCreator %s"
+            (String.concat ~sep:" " target_creation_args)
+          && sh ("java -jar $GATK_JAR -T IndelRealigner"
+                 ^ (if compress then " " else " -compress 0 ")
+                 ^ (String.concat ~sep:" " indel_real_args)))
+    in
+    let output_bam_path input =
+      Filename.chop_extension input#product#path ^ output_suffix ^ ".bam" in
+    let edges =
+      let sequence_dict = (* implicit dependency *)
+        Picard.create_dict ~run_with fasta in
+      [
+        depends_on Tool.(ensure gatk);
+        depends_on fasta;
+        (* RealignerTargetCreator wants the `.fai`: *)
+        depends_on (Samtools.faidx ~run_with fasta);
+        depends_on sequence_dict;
+        on_failure_activate (Remove.file ~run_with intervals_file);
+      ]
+      @ List.concat_map (input_sorted_bam_1 :: more_input_bams) ~f:(fun b -> [
+            depends_on b;
+            depends_on (Samtools.index_to_bai ~run_with b);
+            on_failure_activate (Remove.file ~run_with (output_bam_path b));
+          ])
+    in
+    let node : type a. a bam_or_bams -> a =
+      (* we need a function to force `type a.` *)
+      function
+      | Single_bam b ->
+        (* This is what we give to the `-o` option: *)
+        workflow_node  ~name ~make ~edges
+          (bam_file ~sorting:`Coordinate ~host:Machine.(as_host run_with)
+             (output_bam_path b))
+      | Bam_workflow_list bamlist ->
+        workflow_node  ~name ~make ~edges
+          (bam_list 
+             (List.map bamlist ~f:(fun b ->
+                  (* This is what the documentation says it will to
+                     with the `--nWayOut` option *)
+                  bam_file
+                    ~sorting:`Coordinate ~host:Machine.(as_host run_with)
+                    (output_bam_path b))))
+    in
+    node input_bam_or_bams
 
 (* Again doing two steps in one target for now:
    http://gatkforums.broadinstitute.org/discussion/44/base-quality-score-recalibrator

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -594,63 +594,74 @@ module Compiler = struct
     in
     compiler.wrap_bam_node pipeline bam_node
 
+  let rec compile_bam_pair ~compiler =
+    let {processors ; reference_build; work_dir; machine ;} = compiler in
+    begin function
+    | Bam_pair (
+        Gatk_bqsr (n_bqsr_config, Gatk_indel_realigner (n_gir_conf, n_bam))
+        , 
+        Gatk_bqsr (t_bqsr_config, Gatk_indel_realigner (t_gir_conf, t_bam))
+      ) 
+      when
+        has_option compiler
+          (function `Multi_sample_indel_realignment _ -> true)
+        && n_gir_conf = t_gir_conf ->
+      let normal = compile_aligner_step ~compiler n_bam in
+      let tumor = compile_aligner_step ~compiler t_bam in
+      let bam_list_node =
+        Gatk.indel_realigner
+          ~processors ~reference_build ~run_with:machine ~compress:false
+          ~configuration:n_gir_conf (KEDSL.Bam_workflow_list [normal; tumor])
+      in
+      begin match KEDSL.explode_bam_list_node bam_list_node with
+      | [realigned_normal; realigned_tumor] ->
+        let new_pipeline =
+          Bam_pair (
+            Gatk_bqsr (n_bqsr_config, 
+                       Bam_sample (Filename.chop_extension realigned_normal#product#path,
+                                   realigned_normal)),
+            Gatk_bqsr (t_bqsr_config, 
+                       Bam_sample (Filename.chop_extension realigned_tumor#product#path,
+                                   realigned_tumor)))
+        in
+        compile_bam_pair ~compiler new_pipeline
+      | other ->
+        failwithf "Gatk.indel_realigner did not return the correct list \
+                   of length 2 (tumor, normal): it gave %d bams"
+          (List.length other)
+      end
+    | Bam_pair ( Gatk_bqsr (_, Gatk_indel_realigner (_, _)), 
+                 Gatk_bqsr (_, Gatk_indel_realigner (_, _))) as bam_pair
+      when
+        has_option compiler
+          ((=) (`Multi_sample_indel_realignment `Fail_if_not_happening)) ->
+      failwithf "Option (`Multi_sample_indel_realignment \
+                 `Fail_if_not_happening) is set and this pipeline does not \
+                 qualify:\n%s"
+        (to_json bam_pair |> Yojson.Basic.pretty_to_string)
+    | Bam_pair (normal_t, tumor_t) as final_pipeline ->
+      let normal = compile_aligner_step ~compiler normal_t in
+      let tumor = compile_aligner_step ~compiler tumor_t in
+      (`Normal normal, `Tumor tumor, `Pipeline final_pipeline)
+    end
+
   let rec compile_variant_caller_step ~compiler (pipeline: vcf pipeline) =
     let {processors ; reference_build; work_dir; machine ;} = compiler in
-    let result_prefix = work_dir // to_file_prefix pipeline in
-    dbg "Result_Prefix: %S" result_prefix;
+    (* result prefix ignore optimizations *)
     let vcf_node =
       match pipeline with
-      | Somatic_variant_caller
-          (som_vc,
-           Bam_pair (
-             Gatk_bqsr (n_bqsr_config, Gatk_indel_realigner (n_gir_conf, n_bam))
-             , 
-             Gatk_bqsr (t_bqsr_config, Gatk_indel_realigner (t_gir_conf, t_bam))
-           )) 
-        when
-          has_option compiler
-            (function `Multi_sample_indel_realignment _ -> true)
-          && n_gir_conf = t_gir_conf ->
-        let normal = compile_aligner_step ~compiler n_bam in
-        let tumor = compile_aligner_step ~compiler t_bam in
-        let bam_list_node =
-          Gatk.indel_realigner
-            ~processors ~reference_build ~run_with:machine ~compress:false
-            ~configuration:n_gir_conf (KEDSL.Bam_workflow_list [normal; tumor])
-        in
-        begin match KEDSL.explode_bam_list_node bam_list_node with
-        | [realigned_normal; realigned_tumor] ->
-          let new_pipeline =
-            Somatic_variant_caller
-              (som_vc,
-               (Bam_pair (
-                   Gatk_bqsr (n_bqsr_config, 
-                              Bam_sample (realigned_normal#product#path,
-                                          realigned_normal)),
-                   Gatk_bqsr (t_bqsr_config, 
-                              Bam_sample (realigned_tumor#product#path,
-                                          realigned_tumor)))))
-          in
-          compile_variant_caller_step ~compiler new_pipeline
-        | other ->
-          failwithf "Gatk.indel_realigner did not return the correct list \
-                     of length 2 (tumor, normal): it gave %d bams"
-            (List.length other)
-        end
-      | Somatic_variant_caller (som_vc, Bam_pair (_, _)) as soma_pipeline
-        when
-          has_option compiler
-            ((=) (`Multi_sample_indel_realignment `Fail_if_not_happening)) ->
-        failwithf "Option (`Multi_sample_indel_realignment \
-                   `Fail_if_not_happening) is set and this pipeline does not \
-                   qualify:\n%s"
-          (to_json soma_pipeline |> Yojson.Basic.pretty_to_string)
-      | Somatic_variant_caller (som_vc, Bam_pair (normal_t, tumor_t)) ->
-        let normal = compile_aligner_step ~compiler normal_t in
-        let tumor = compile_aligner_step ~compiler tumor_t in
+      | Somatic_variant_caller (som_vc, bam_pair) ->
+        let (`Normal normal, `Tumor tumor, `Pipeline new_bam_pair) =
+          compile_bam_pair ~compiler bam_pair in
+        let result_prefix =
+          work_dir
+          // to_file_prefix (Somatic_variant_caller (som_vc, new_bam_pair)) in
+        dbg "Result_Prefix: %S" result_prefix;
         som_vc.Somatic_variant_caller.make_target ~reference_build ~processors
           ~run_with:machine ~normal ~tumor ~result_prefix ()
       | Germline_variant_caller (gvc, bam) ->
+        let result_prefix = work_dir // to_file_prefix pipeline in
+        dbg "Result_Prefix: %S" result_prefix;
         let input_bam = compile_aligner_step ~compiler bam in
         gvc.Germline_variant_caller.make_target ~processors ~reference_build
           ~run_with:machine ~input_bam ~result_prefix ()

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -615,7 +615,7 @@ module Compiler = struct
             ~processors ~reference_build ~run_with:machine ~compress:false
             ~configuration:n_gir_conf (KEDSL.Bam_workflow_list [normal; tumor])
         in
-        begin match KEDSL.expolode_bam_list_node bam_list_node with
+        begin match KEDSL.explode_bam_list_node bam_list_node with
         | [realigned_normal; realigned_tumor] ->
           let new_pipeline =
             Somatic_variant_caller

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -542,10 +542,9 @@ module Compiler = struct
       | Bam_sample (name, bam_target) -> bam_target
       | Gatk_indel_realigner (configuration, bam) ->
         let input_bam = compile_aligner_step ~compiler bam in
-        let output_bam = result_prefix ^ ".bam" in
         Gatk.indel_realigner
-          ~processors ~reference_build ~run_with:machine input_bam ~compress:false
-          ~configuration ~output_bam
+          ~processors ~reference_build ~run_with:machine ~compress:false
+          ~configuration (KEDSL.Single_bam input_bam)
       | Gatk_bqsr (configuration, bam) ->
         let input_bam = compile_aligner_step ~compiler bam in
         let output_bam = result_prefix ^ ".bam" in


### PR DESCRIPTION

This is for #125.

The function `Gatk.indel_realigner` can take an arbitrary list of bams.

At the `Pipeline.t` level, this is, for now, implemented as an optional "compiler optimization."
It will detect pipelines of the form `somatic_variant_caller (indel |> bqsr, indel |> bqsr)` and run the indel-realigner on both the tumor and normal together and then before re-split for bqsr.

I haven't properly tested yet (I've generated the ketrew pipelines and looked at them, but haven't run GATK & co because I'm cluster-orphan these days), but while this gets run, having more eyes on the code would be nice, hence the PR :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/150)
<!-- Reviewable:end -->
