### PR TITLE
Add sorting of DbSNP VCFs

### DIFF
--- a/src/lib/download_reference_genomes.ml
+++ b/src/lib/download_reference_genomes.ml
@@ -30,9 +30,18 @@ let of_specification
       let vcfs =
         List.map ~f:(fun (n, loc) -> compile_location n loc) l
       in
-      let final_vcf = dest_file filename in
       let vcftools = Tool.Kit.get_exn toolkit Tool.Default.vcftools in
-      Vcftools.vcf_concat_no_machine ~host ~vcftools ~run_program ~final_vcf vcfs
+      let concated =
+        let tmp_vcf =
+          dest_file (Filename.chop_extension filename ^ "-cat.vcf") in
+        Vcftools.vcf_concat_no_machine
+          ~host ~vcftools ~run_program ~final_vcf:tmp_vcf vcfs in
+      let sorted =
+        let final_vcf_path = dest_file filename in
+        Vcftools.vcf_sort_no_machine
+          ~host ~vcftools ~run_program
+          ~src:concated ~dest:final_vcf_path () in
+      sorted
     | other ->
       failwithf "Reference_genome.compile_location this kind of location \
                  is not yet implemented"

--- a/src/lib/vcftools.ml
+++ b/src/lib/vcftools.ml
@@ -4,6 +4,10 @@ open Workflow_utilities
 
 
 
+(** 
+   Call a command on a list of [~vcfs] to produce a given [~final_vcf] (hence
+   the {i n-to-1} naming).
+*)
 let vcf_process_n_to_1_no_machine
     ~host
     ~vcftools
@@ -34,8 +38,11 @@ let vcf_process_n_to_1_no_machine
       :: List.map ~f:depends_on vcfs
       @ more_edges)
 
-(* We use this version where we don't yet have a Machine.t, as in
-   download_reference_genome.ml
+(**
+   Concatenate VCF files. 
+
+   We use this version where we don't yet have a Machine.t, as in
+   ["download_reference_genome.ml"].
 *)
 let vcf_concat_no_machine
     ~host
@@ -48,6 +55,13 @@ let vcf_concat_no_machine
     ~host ~vcftools ~run_program ?more_edges ~vcfs ~final_vcf
     "vcf-concat"
 
+(**
+   Sort a VCF file by choromosome position (it uses ["vcf-sort"] which itself
+   relies on the ["sort"] unix tool having the ["--version-sort"] option). 
+
+   We use this version where we don't yet have a Machine.t, as in
+   ["download_reference_genome.ml"].
+*)
 let vcf_sort_no_machine
     ~host
     ~vcftools

--- a/src/lib/vcftools.ml
+++ b/src/lib/vcftools.ml
@@ -3,38 +3,60 @@ open Run_environment
 open Workflow_utilities
 
 
-(* We use this version where we don't yet have a Machine.t, as in
-   download_reference_genome.ml *)
-let vcf_concat_no_machine
+
+let vcf_process_n_to_1_no_machine
     ~host
     ~vcftools
     ~(run_program : Machine.run_function)
     ?(more_edges = [])
+    ~vcfs
+    ~final_vcf
+    command_prefix
+  =
+  let open KEDSL in
+  let name = sprintf "%s-%s" command_prefix (Filename.basename final_vcf) in
+  let make =
+    run_program ~name
+      Program.(
+        Tool.(init vcftools)
+        && shf "%s %s > %s"
+          command_prefix
+          (String.concat ~sep:" "
+             (List.map vcfs ~f:(fun t -> Filename.quote t#product#path)))
+          final_vcf
+      ) in
+  workflow_node ~name
+    (single_file final_vcf ~host)
+    ~make
+    ~edges:(
+      on_failure_activate (Remove.path_on_host ~host final_vcf)
+      :: depends_on Tool.(ensure vcftools)
+      :: List.map ~f:depends_on vcfs
+      @ more_edges)
+
+(* We use this version where we don't yet have a Machine.t, as in
+   download_reference_genome.ml
+*)
+let vcf_concat_no_machine
+    ~host
+    ~vcftools
+    ~(run_program : Machine.run_function)
+    ?more_edges
     vcfs
     ~final_vcf =
-  let open KEDSL in
-  let name = sprintf "merge-vcfs-%s" (Filename.basename final_vcf) in
-  let vcf_concat =
-    let make =
-      run_program ~name
-        Program.(
-          Tool.(init vcftools)
-          && shf "vcf-concat %s > %s"
-            (String.concat ~sep:" "
-               (List.map vcfs ~f:(fun t -> t#product#path)))
-            final_vcf
-        ) in
-    workflow_node ~name
-      (single_file final_vcf ~host)
-      ~make
-      ~edges:(
-        on_failure_activate (Remove.path_on_host ~host final_vcf)
-        :: depends_on Tool.(ensure vcftools)
-        :: List.map ~f:depends_on vcfs
-        @ more_edges)
-  in
-  vcf_concat
+  vcf_process_n_to_1_no_machine
+    ~host ~vcftools ~run_program ?more_edges ~vcfs ~final_vcf
+    "vcf-concat"
 
+let vcf_sort_no_machine
+    ~host
+    ~vcftools
+    ~(run_program : Machine.run_function)
+    ?more_edges
+    ~src ~dest () =
+  vcf_process_n_to_1_no_machine
+    ~host ~vcftools ~run_program ?more_edges ~vcfs:[src] ~final_vcf:dest
+    "vcf-sort -c"
 
 let vcf_concat ~(run_with:Machine.t) ?more_edges vcfs ~final_vcf =
   let vcftools = Machine.get_tool run_with Tool.Default.vcftools in


### PR DESCRIPTION

This adds a `vcf-sort` step after downloading MM10's DbSNP's SNPs and INDELs.

So this is a fix for #134 to run BQSR on MM10, but not for #135 for which we need
to come up with decent semantics for `#dbsnp` and a consistent API.

I've run
[`src/test/all_downloads.ml`](https://github.com/hammerlab/biokepi/blob/master/src/test/all_downloads.ml)
and the result looks sorted.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/152)
<!-- Reviewable:end -->
