### PR TITLE
Do various fixes

### DIFF
--- a/src/lib/gatk.ml
+++ b/src/lib/gatk.ml
@@ -293,12 +293,13 @@ let base_quality_score_recalibrator
   let reference_genome = Machine.get_reference_genome run_with reference_build in
   let fasta = Reference_genome.fasta reference_genome in
   let db_snp = Reference_genome.dbsnp_exn reference_genome in
-  let recal_data_table =
-    Filename.chop_suffix input_bam#product#path ".bam" ^ "-recal_data.table"
-  in
   let sorted_bam =
     Samtools.sort_bam_if_necessary
       ~run_with ~processors ~by:`Coordinate input_bam in
+  let input_bam = `Please_use_the_sorted_one in ignore input_bam;
+  let recal_data_table =
+    Filename.chop_suffix sorted_bam#product#path ".bam" ^ "-recal_data.table"
+  in
   let make =
     Machine.run_program run_with ~name
       Program.(

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -326,7 +326,7 @@ let rec to_file_prefix:
       | Some (`R2 s) -> sprintf "%s-R2-cat" s
       end
     | Concat_text _ -> failwith "TODO"
-    | Bam_sample (name, _) -> name
+    | Bam_sample (name, _) -> Filename.basename name
     | Bam_to_fastq (how, bam) ->
       sprintf "%s-b2fq-%s"
         (to_file_prefix bam)


### PR DESCRIPTION

Now that I have a cluster, could do more tests:

- GATK's indel-realigner with `--nWayOut` also does a `basename` on the input bams so it outputs to the “current” directory. Hence had to `cd` there to have proper file paths.
- There was a bug in `Pipeline.to_file_prefix` that the optmization pass exhibited.
- There was a 99.9% silent bug in `Gatk.bqsr` with the path to the `-recal_data.table` file that I saw while reading the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/161)
<!-- Reviewable:end -->
