### PR TITLE
Fix missing `~host` in `get_broad_jar`

### DIFF
--- a/src/lib/tool_providers.ml
+++ b/src/lib/tool_providers.ml
@@ -380,7 +380,7 @@ let get_broad_jar ~host ~install_path loc =
     ~edges:[
       on_failure_activate (rm_path ~host local_box_path)
     ]
-    ~make:(daemonize ~using:`Python_daemon
+    ~make:(daemonize ~using:`Python_daemon ~host
              Program.(
                shf "mkdir -p %s" install_path
                && begin match loc with


### PR DESCRIPTION
It seems that since the last time we changed all that code, we have tested this
one only with Ketrew servers that have a shared file-system with the host that
runs the jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/170)
<!-- Reviewable:end -->
