### PR TITLE
Implement “requirements” for `Machine.run_program`

### DIFF
--- a/src/lib/build_machine.ml
+++ b/src/lib/build_machine.ml
@@ -2,8 +2,8 @@ open Common
 
 open Run_environment
 
-let default_run_program : host:KEDSL.Host.t -> Machine.run_function =
-  fun ~host ?(name="biokepi-ssh-box") ?(processors=1) program ->
+let default_run_program : host:KEDSL.Host.t -> Make_fun.t =
+  fun ~host ?(name="biokepi-ssh-box") ?(requirements = []) program ->
     let open KEDSL in
     daemonize ~using:`Python_daemon ~host program
 
@@ -36,5 +36,4 @@ let create
     ~host
     ~toolkit
     ~run_program
-    ~quick_command:(fun program -> run_program program)
     ~work_dir:(meta_playground // "work")

--- a/src/lib/build_machine.mli
+++ b/src/lib/build_machine.mli
@@ -17,6 +17,6 @@
 val create :
   ?gatk_jar_location:(unit -> Tool_providers.broad_jar_location) ->
   ?mutect_jar_location:(unit -> Tool_providers.broad_jar_location) ->
-  ?run_program:Run_environment.Machine.run_function ->
+  ?run_program:Run_environment.Make_fun.t ->
   ?b37:Reference_genome.t -> string ->
   Run_environment.Machine.t

--- a/src/lib/bwa.ml
+++ b/src/lib/bwa.ml
@@ -28,7 +28,7 @@ let index
       depends_on Tool.(ensure bwa_tool);
     ]
     ~tags:[Target_tags.aligner]
-    ~make:(Machine.run_program run_with ~processors:1 ~name
+    ~make:(Machine.run_big_program run_with ~processors:1 ~name
              Program.(
                Tool.(init bwa_tool)
                && shf "bwa index %s"
@@ -92,7 +92,7 @@ let mem_align_to_sam
         :: on_failure_activate (Remove.file ~run_with result)
         :: [])
       ~tags:[Target_tags.aligner]
-      ~make:(Machine.run_program run_with ~processors ~name
+      ~make:(Machine.run_big_program run_with ~processors ~name
                Program.(
                  Tool.(init bwa_tool)
                  && in_work_dir
@@ -160,7 +160,7 @@ let align_to_sam
         on_failure_activate (Remove.file ~run_with result);
       ]
       ~tags:[Target_tags.aligner]
-      ~make:(Machine.run_program run_with ~processors ~name
+      ~make:(Machine.run_big_program run_with ~processors ~name
                Program.(
                  Tool.(init bwa_tool)
                  && in_work_dir
@@ -210,6 +210,6 @@ let align_to_sam
       (single_file result ~host:Machine.(as_host run_with))
       ~name ~edges
       ~tags:[Target_tags.aligner]
-      ~make:(Machine.run_program run_with ~processors:1 ~name  program)
+      ~make:(Machine.run_big_program run_with ~processors:1 ~name  program)
   in
   sam

--- a/src/lib/cufflinks.ml
+++ b/src/lib/cufflinks.ml
@@ -22,7 +22,7 @@ let run ~reference_build
   let sorted_bam =
     Samtools.sort_bam_if_necessary ~run_with ~processors ~by:`Coordinate bam in
   let make =
-    Machine.run_program run_with ~name ~processors
+    Machine.run_big_program run_with ~name ~processors
       Program.(
         Tool.init cufflinks_tool
         && shf "mkdir -p %s" output_dir

--- a/src/lib/cycledash.ml
+++ b/src/lib/cycledash.ml
@@ -39,7 +39,7 @@ let post_vcf
   let name =
     sprintf "upload+cycledash: %s" (Filename.basename vcf#product#path) in
   let make =
-    Machine.quick_command run_with Program.(
+    Machine.run_download_program run_with Program.(
         shf "curl -f %s > %s"
           (Filename.quote post_to_cycledash_script)
           (Filename.quote unik_script)

--- a/src/lib/download_reference_genomes.ml
+++ b/src/lib/download_reference_genomes.ml
@@ -58,31 +58,31 @@ let of_specification
 type pull_function =
   toolkit:Run_environment.Tool.Kit.t ->
   host:Common.KEDSL.Host.t ->
-  run_program:Run_environment.Machine.run_function ->
+  run_program:Run_environment.Make_fun.t ->
   destination_path:string -> Reference_genome.t
 
 
-let pull_b37 ~toolkit ~host ~(run_program : Machine.run_function) ~destination_path =
+let pull_b37 ~toolkit ~host ~(run_program : Make_fun.t) ~destination_path =
   of_specification ~toolkit ~host ~run_program ~destination_path
     Reference_genome.Specification.Default.b37
 
-let pull_b37decoy ~toolkit ~host ~(run_program : Machine.run_function) ~destination_path =
+let pull_b37decoy ~toolkit ~host ~(run_program : Make_fun.t) ~destination_path =
   of_specification ~toolkit ~host ~run_program ~destination_path
     Reference_genome.Specification.Default.b37decoy
 
-let pull_b38 ~toolkit ~host ~(run_program : Machine.run_function) ~destination_path =
+let pull_b38 ~toolkit ~host ~(run_program : Make_fun.t) ~destination_path =
   of_specification ~toolkit ~host ~run_program ~destination_path
     Reference_genome.Specification.Default.b38
 
-let pull_hg19 ~toolkit ~host ~(run_program : Machine.run_function) ~destination_path =
+let pull_hg19 ~toolkit ~host ~(run_program : Make_fun.t) ~destination_path =
   of_specification ~toolkit ~host ~run_program ~destination_path
     Reference_genome.Specification.Default.hg19
 
-let pull_hg18 ~toolkit ~host ~(run_program : Machine.run_function) ~destination_path =
+let pull_hg18 ~toolkit ~host ~(run_program : Make_fun.t) ~destination_path =
   of_specification ~toolkit ~host ~run_program ~destination_path
     Reference_genome.Specification.Default.hg18
 
-let pull_mm10 ~toolkit ~host ~(run_program : Machine.run_function) ~destination_path =
+let pull_mm10 ~toolkit ~host ~(run_program : Make_fun.t) ~destination_path =
   of_specification ~toolkit ~host ~run_program ~destination_path
     Reference_genome.Specification.Default.mm10
 

--- a/src/lib/download_reference_genomes.mli
+++ b/src/lib/download_reference_genomes.mli
@@ -3,7 +3,7 @@
 type pull_function =
   toolkit:Run_environment.Tool.Kit.t ->
   host:Common.KEDSL.Host.t ->
-  run_program:Run_environment.Machine.run_function ->
+  run_program:Run_environment.Make_fun.t ->
   destination_path:string -> Reference_genome.t
 
 val pull_b37 : pull_function

--- a/src/lib/hisat.ml
+++ b/src/lib/hisat.ml
@@ -25,7 +25,7 @@ let index
       depends_on Tool.(ensure hisat_tool);
     ]
     ~tags:[Target_tags.aligner]
-    ~make:(Machine.run_program run_with ~processors ~name
+    ~make:(Machine.run_big_program run_with ~processors ~name
             Program.(
               Tool.(init hisat_tool)
               && shf "mkdir %s" result_dir 
@@ -77,7 +77,7 @@ let align
         depends_on Tool.(ensure hisat_tool);
       ]
       ~tags:[Target_tags.aligner]
-      ~make:(Machine.run_program run_with ~processors ~name
+      ~make:(Machine.run_big_program run_with ~processors ~name
                Program.(
                  Tool.(init hisat_tool)
                  && in_work_dir

--- a/src/lib/kallisto.ml
+++ b/src/lib/kallisto.ml
@@ -25,7 +25,7 @@ let index
       depends_on reference_transcriptome;
       depends_on Tool.(ensure kallisto_tool);
     ]
-    ~make:(Machine.run_program run_with ~processors ~name
+    ~make:(Machine.run_big_program run_with ~processors ~name
             Program.(
               Tool.(init kallisto_tool)
               && shf "kallisto index -i %s %s"
@@ -70,7 +70,7 @@ let run
     | None -> kallisto_quant_base_cmd
   in
   let make =
-    Machine.run_program run_with ~name ~processors
+    Machine.run_big_program run_with ~name ~processors
       Program.(
         Tool.init kallisto_tool
         && sh kallisto_quant

--- a/src/lib/mosaik.ml
+++ b/src/lib/mosaik.ml
@@ -25,7 +25,7 @@ let index
       depends_on Tool.(ensure mosaik_tool);
     ]
     ~tags:[Target_tags.aligner]
-    ~make:(Machine.run_program run_with ~processors ~name
+    ~make:(Machine.run_big_program run_with ~processors ~name
             Program.(
               Tool.(init mosaik_tool)
               && shf "mkdir -p %s" mosaik_tmp_dir
@@ -108,7 +108,7 @@ let align
         depends_on Tool.(ensure mosaik_tool);
       ]
       ~tags:[Target_tags.aligner]
-      ~make:(Machine.run_program run_with ~processors ~name
+      ~make:(Machine.run_big_program run_with ~processors ~name
                Program.(
                  Tool.(init mosaik_tool)
                  && in_work_dir

--- a/src/lib/mutect.ml
+++ b/src/lib/mutect.ml
@@ -74,7 +74,7 @@ let run ~reference_build
         Option.value_map ~default:"" dbsnp ~f:(fun node ->
             sprintf "--dbsnp %s" (Filename.quote node#product#path)) in
       let make =
-        Machine.run_program run_with ~name ~processors:2 Program.(
+        Machine.run_big_program run_with ~name ~processors:2 Program.(
             Tool.(init mutect)
             && shf "mkdir -p %s" run_path
             && shf "cd %s" run_path

--- a/src/lib/run_environment.ml
+++ b/src/lib/run_environment.ml
@@ -123,9 +123,6 @@ end
 
 module Machine = struct
 
-  (* type run_function = ?name:string -> ?processors:int -> Program.t -> *)
-  (*   Ketrew_pure.Target.Build_process.t *)
-
   type t = {
     name: string;
     ssh_name: string;

--- a/src/lib/run_environment.ml
+++ b/src/lib/run_environment.ml
@@ -112,9 +112,10 @@ module Make_fun = struct
     Program.t ->
     KEDSL.Build_process.t
 
-  let streamish requirements = `Processors 1 :: `Memory `Decent :: requirements
+  let stream_processor requirements = `Processors 1 :: `Memory `Decent :: requirements
   let quick requirements = `Quick_run :: requirements
-  let downloading requirements = `Internet_access :: streamish requirements 
+  let downloading requirements =
+    `Internet_access :: stream_processor requirements 
 
   let with_requirements : t -> Requirement.t list -> t = fun f l ->
     fun ?name ?(requirements = []) prog ->
@@ -149,17 +150,19 @@ module Machine = struct
   let quick_run_program t : Make_fun.t =
     Make_fun.with_requirements t.run_program (Make_fun.quick [])
 
-  (** Run a program that does not use much memory and runs on one core *)
-  let run_streamish_program t : Make_fun.t =
-    Make_fun.with_requirements t.run_program (Make_fun.streamish [])
+  (** Run a program that does not use much memory and runs on one core. *)
+  let run_stream_processor t : Make_fun.t =
+    Make_fun.with_requirements t.run_program (Make_fun.stream_processor [])
 
-  (** Run a program that does not use much memory, runs on one core, and uses the internet *)
+  (** Run a program that does not use much memory, runs on one core, and needs
+      the internet. *)
   let run_download_program t : Make_fun.t =
     Make_fun.with_requirements t.run_program (Make_fun.downloading [])
 
   let run_big_program t : ?processors: int -> Make_fun.t =
     fun ?(processors = 1) ->
-      Make_fun.with_requirements t.run_program [`Memory `Big; `Processors processors]
+      Make_fun.with_requirements
+        t.run_program [`Memory `Big; `Processors processors]
 
   let work_dir t = t.work_dir
 

--- a/src/lib/somaticsniper.ml
+++ b/src/lib/somaticsniper.ml
@@ -27,7 +27,7 @@ let run ~reference_build
   let sorted_tumor =
     Samtools.sort_bam_if_necessary ~run_with ~by:`Coordinate tumor in
   let make =
-    Machine.run_program run_with
+    Machine.run_big_program run_with
       ~name ~processors:1 Program.(
           Tool.init sniper
           && shf "mkdir -p %s" run_path

--- a/src/lib/star.ml
+++ b/src/lib/star.ml
@@ -26,7 +26,7 @@ let index
       depends_on Tool.(ensure star_tool);
     ]
     ~tags:[Target_tags.aligner]
-    ~make:(Machine.run_program run_with ~processors ~name
+    ~make:(Machine.run_big_program run_with ~processors ~name
             Program.(
               Tool.(init star_tool)
               && shf "mkdir %s" result_dir 
@@ -91,7 +91,7 @@ let align
             depends_on Tool.(ensure star_tool);
         ]
         ~tags:[Target_tags.aligner]
-        ~make:(Machine.run_program run_with ~processors ~name
+        ~make:(Machine.run_big_program run_with ~processors ~name
              Program.(
                Tool.(init star_tool)
                && in_work_dir

--- a/src/lib/strelka.ml
+++ b/src/lib/strelka.ml
@@ -141,7 +141,7 @@ let run ~reference_build
       ~run_with ~processors ~by:`Coordinate tumor in
   let working_dir = Filename.(dirname result_prefix) in
   let make =
-    Machine.run_program run_with ~name ~processors
+    Machine.run_big_program run_with ~name ~processors
       Program.(
         Tool.init strelka_tool && Tool.init gatk_tool
         && shf "mkdir -p %s"  working_dir

--- a/src/lib/stringtie.ml
+++ b/src/lib/stringtie.ml
@@ -50,7 +50,7 @@ let run
     let reference_annotations_option =
       Option.value_map ~default:"" reference_annotations
         ~f:(fun o -> sprintf "-G %s" Filename.(quote o#product#path)) in
-    Machine.run_program run_with ~name ~processors
+    Machine.run_big_program run_with ~name ~processors
       Program.(
         Tool.init stringtie_tool
         && shf "mkdir -p %s" output_dir

--- a/src/lib/varscan.ml
+++ b/src/lib/varscan.ml
@@ -60,7 +60,7 @@ let somatic_on_region
         ^ " fi "
       in
       Program.(Tool.init varscan_tool && sh big_one_liner)
-      |> Machine.run_program run_with ~name ~processors:1
+      |> Machine.run_big_program run_with ~name ~processors:1
     in
     workflow_node ~name ~make
       (single_file snp_output ~host)
@@ -89,7 +89,7 @@ let somatic_on_region
         && shf "java -jar $VARSCAN_JAR processSomatic %s" snp_filtered
         && shf "java -jar $VARSCAN_JAR processSomatic %s" indel_output
       )
-      |> Machine.run_program run_with ~name ~processors:1
+      |> Machine.run_big_program run_with ~name ~processors:1
     in
     workflow_node ~name
       (single_file snp_filtered ~host) ~make ~tags

--- a/src/lib/vcftools.ml
+++ b/src/lib/vcftools.ml
@@ -11,7 +11,7 @@ open Workflow_utilities
 let vcf_process_n_to_1_no_machine
     ~host
     ~vcftools
-    ~(run_program : Machine.run_function)
+    ~(run_program : Make_fun.t)
     ?(more_edges = [])
     ~vcfs
     ~final_vcf
@@ -47,7 +47,7 @@ let vcf_process_n_to_1_no_machine
 let vcf_concat_no_machine
     ~host
     ~vcftools
-    ~(run_program : Machine.run_function)
+    ~(run_program : Make_fun.t)
     ?more_edges
     vcfs
     ~final_vcf =
@@ -65,9 +65,10 @@ let vcf_concat_no_machine
 let vcf_sort_no_machine
     ~host
     ~vcftools
-    ~(run_program : Machine.run_function)
+    ~(run_program : Make_fun.t)
     ?more_edges
     ~src ~dest () =
+  let run_program = Make_fun.with_requirements run_program [`Memory `Big] in 
   vcf_process_n_to_1_no_machine
     ~host ~vcftools ~run_program ?more_edges ~vcfs:[src] ~final_vcf:dest
     "vcf-sort -c"

--- a/src/lib/virmid.ml
+++ b/src/lib/virmid.ml
@@ -52,7 +52,7 @@ let run ~reference_build
        annoyed by the a space in the header. *)
     work_dir // Filename.basename tumor#product#path ^ ".virmid.som.passed.vcf" in
   let make =
-    Machine.run_program run_with ~name ~processors
+    Machine.run_big_program run_with ~name ~processors
       Program.(
         Tool.init virmid_tool
         && shf "mkdir -p %s" work_dir

--- a/src/lib/workflow_utilities.ml
+++ b/src/lib/workflow_utilities.ml
@@ -14,7 +14,8 @@ module Remove = struct
             (sprintf "ls %s" path),
           2
         ))
-      ~make:(Machine.quick_command run_with Program.(exec ["rm"; "-f"; path]))
+      ~make:(Machine.quick_run_program
+               run_with Program.(exec ["rm"; "-f"; path]))
       ~tags:[Target_tags.clean_up]
 
   let directory ~run_with path =
@@ -26,7 +27,8 @@ module Remove = struct
             (sprintf "ls %s" path),
           2
         ))
-      ~make:(Machine.quick_command run_with Program.(exec ["rm"; "-rf"; path]))
+      ~make:(Machine.quick_run_program
+               run_with Program.(exec ["rm"; "-rf"; path]))
       ~tags:[Target_tags.clean_up]
 
   (* This one is dirtier, it does not check its result and uses the `Host.t`
@@ -60,7 +62,9 @@ module Gunzip = struct
     workflow_node
       (single_file result_path ~host:Machine.(as_host run_with))
       ~name
-      ~make:(Machine.run_program run_with ~processors:1 ~name  program)
+      ~make:(Machine.run_program ~name
+               ~requirements:[`Processors 1; `Memory `Decent]
+               run_with  program)
       ~edges:(
         on_failure_activate Remove.(file ~run_with result_path)
         :: List.map ~f:depends_on bunch_of_dot_gzs)
@@ -86,9 +90,10 @@ module Cat = struct
       ~edges:(
         on_failure_activate Remove.(file ~run_with result_path)
         :: List.map ~f:depends_on bunch_of_files)
-      ~make:(Machine.run_program run_with ~processors:1 ~name  program)
+      ~make:(Machine.run_streamish_program run_with ~name  program)
 
-  let cat_folder ~host ~(run_program : Machine.run_function)
+  let cat_folder ~host
+      ~(run_program : Run_environment.Make_fun.t)
       ?(depends_on=[]) ~files_gzipped ~folder ~destination = 
     let deps = depends_on in
     let open KEDSL in
@@ -100,15 +105,16 @@ module Cat = struct
       workflow_node (single_file destination ~host)
         ~edges ~name
         ~make:(
-          run_program ~name ~processors:1
+          run_program ~name
             Program.(
-              shf "gunzip -c %s/* > %s" (Filename.quote folder) (Filename.quote destination)))
+              shf "gunzip -c %s/* > %s" (Filename.quote folder)
+                (Filename.quote destination)))
     ) else (
       workflow_node
         (single_file destination ~host)
         ~edges ~name
         ~make:(
-          run_program ~name ~processors:1
+          run_program ~name
             Program.(
               shf "cat %s/* > %s" (Filename.quote folder) (Filename.quote destination)))
     )
@@ -124,13 +130,16 @@ module Download = struct
       url
     ]
 
-  let wget_to_folder ~host ~(run_program : Machine.run_function) ~test_file ~destination url  =
+  let wget_to_folder
+      ~host ~(run_program : Run_environment.Make_fun.t)
+      ~test_file ~destination url  =
     let open KEDSL in
     let name = "wget-" ^ Filename.basename destination in
     let test_target = destination // test_file in
     workflow_node (single_file test_target ~host) ~name
       ~make:(
-        run_program ~name ~processors:1
+        run_program ~name
+          ~requirements:(Make_fun.downloading [])
           Program.(
             exec ["mkdir"; "-p"; destination]
             && shf "wget %s -P %s"
@@ -140,13 +149,16 @@ module Download = struct
         on_failure_activate (Remove.path_on_host ~host destination);
       ]
 
-  let wget ~host ~(run_program : Machine.run_function) url destination =
+  let wget
+      ~host ~(run_program : Run_environment.Make_fun.t)
+      url destination =
     let open KEDSL in
     let name = "wget-" ^ Filename.basename destination in
     workflow_node
       (single_file destination ~host) ~name
       ~make:(
-        run_program ~name ~processors:1
+        run_program ~name
+          ~requirements:(Make_fun.downloading [])
           Program.(
             exec ["mkdir"; "-p"; Filename.dirname destination]
             && shf "wget %s -O %s"
@@ -155,7 +167,9 @@ module Download = struct
         on_failure_activate (Remove.path_on_host ~host destination);
       ]
 
-  let wget_gunzip ~host ~(run_program : Machine.run_function) ~destination url =
+  let wget_gunzip
+      ~host ~(run_program : Run_environment.Make_fun.t)
+      ~destination url =
     let open KEDSL in
     let is_gz = Filename.check_suffix url ".gz" in
     if is_gz then (
@@ -169,7 +183,8 @@ module Download = struct
         ]
         ~name
         ~make:(
-          run_program ~name ~processors:1
+          run_program ~name
+            ~requirements:(Make_fun.streamish [])
             Program.(shf "gunzip -c %s > %s"
                        (Filename.quote wgot#product#path)
                        (Filename.quote destination)))
@@ -177,7 +192,8 @@ module Download = struct
       wget ~host ~run_program url destination
     )
 
-  let wget_untar ~host ~(run_program : Machine.run_function)
+  let wget_untar
+      ~host ~(run_program : Run_environment.Make_fun.t)
       ~destination_folder ~tar_contains url =
     let open KEDSL in
     let zip_flags =
@@ -197,7 +213,8 @@ module Download = struct
       ]
       ~name
       ~make:(
-        run_program ~name ~processors:1
+        run_program ~name
+          ~requirements:(Make_fun.streamish [])
           Program.(
             exec ["mkdir"; "-p"; destination_folder]
             && shf "tar -x%s -f %s -C %s"

--- a/src/lib/workflow_utilities.ml
+++ b/src/lib/workflow_utilities.ml
@@ -90,7 +90,7 @@ module Cat = struct
       ~edges:(
         on_failure_activate Remove.(file ~run_with result_path)
         :: List.map ~f:depends_on bunch_of_files)
-      ~make:(Machine.run_streamish_program run_with ~name  program)
+      ~make:(Machine.run_stream_processor run_with ~name  program)
 
   let cat_folder ~host
       ~(run_program : Run_environment.Make_fun.t)
@@ -184,7 +184,7 @@ module Download = struct
         ~name
         ~make:(
           run_program ~name
-            ~requirements:(Make_fun.streamish [])
+            ~requirements:(Make_fun.stream_processor [])
             Program.(shf "gunzip -c %s > %s"
                        (Filename.quote wgot#product#path)
                        (Filename.quote destination)))
@@ -214,7 +214,7 @@ module Download = struct
       ~name
       ~make:(
         run_program ~name
-          ~requirements:(Make_fun.streamish [])
+          ~requirements:(Make_fun.stream_processor [])
           Program.(
             exec ["mkdir"; "-p"; destination_folder]
             && shf "tar -x%s -f %s -C %s"

--- a/src/lib/workflow_utilities.ml
+++ b/src/lib/workflow_utilities.ml
@@ -62,9 +62,7 @@ module Gunzip = struct
     workflow_node
       (single_file result_path ~host:Machine.(as_host run_with))
       ~name
-      ~make:(Machine.run_program ~name
-               ~requirements:[`Processors 1; `Memory `Decent]
-               run_with  program)
+      ~make:(Machine.run_stream_processor ~name run_with  program)
       ~edges:(
         on_failure_activate Remove.(file ~run_with result_path)
         :: List.map ~f:depends_on bunch_of_dot_gzs)

--- a/src/test/all_downloads.ml
+++ b/src/test/all_downloads.ml
@@ -18,7 +18,7 @@ let host =
 let destination_path =
   get_env "DEST_PATH" "Directory path on the host where every download should go"
 
-let run_program ?name ?processors prog =
+let run_program ?name ?requirements prog =
   let open Ketrew.EDSL in
   daemonize ~using:`Python_daemon ~host prog
 


### PR DESCRIPTION
The idea is that users of the `Make_fun.t` functions express their needs with a
`~requirements` argument.

Both the `Make_fun` and `Machine` modules provide functions with default
values.

The `Make_fun.Requirement.t` variants are of course just a first stab to be
refined later (and some cases are not used anywhere).

This “fixes” #163.

We can start taking notes when we run tools, so that they can give a better
estimate of their memory requirements (cf. #166).

I came across #179 but did not fix it yet (I actually don't really know these
tools).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/180)
<!-- Reviewable:end -->
