### PR TITLE
Make `Picard.mark_duplicates` a “big” program

### DIFF
--- a/src/lib/picard.ml
+++ b/src/lib/picard.ml
@@ -124,7 +124,7 @@ let mark_duplicates
                metrics_path) in
   let name =
     sprintf "picard-markdups-%s" Filename.(basename input_bam#product#path) in
-  let make = Machine.run_program ~name run_with program in
+  let make = Machine.run_big_program ~name run_with program in
   let host = Machine.(as_host run_with) in
   workflow_node (bam_file ~sorting:`Coordinate output_bam ~host)
     ~name ~make


### PR DESCRIPTION
On pretty standard data, mark-dups went way over 5 GB which is our current
heuristic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/196)
<!-- Reviewable:end -->
