### PR TITLE
Merge Indels and SNVs properly for Strelka

### DIFF
--- a/src/lib/strelka.ml
+++ b/src/lib/strelka.ml
@@ -163,11 +163,11 @@ let run ~reference_build
         && shf "cd %s" output_dir
         && shf "make -j%d" processors
         && Gatk.call_gatk ~analysis:"CombineVariants" [
-          "--variant"; "results/passed.somatic.snvs.vcf";
-          "--variant"; "results/passed.somatic.indels.vcf";
+          "--variant:snvs"; "results/passed.somatic.snvs.vcf";
+          "--variant:indels"; "results/passed.somatic.indels.vcf";
           "-R"; reference_fasta#product#path;
-          "-genotypeMergeOptions"; "UNIQUIFY";
-          "-o"; output_file_path;
+          "-genotypeMergeOptions"; "PRIORITIZE";
+          "-o"; output_file_path; "-priority"; "snvs,indels"
         ]
       )
   in


### PR DESCRIPTION
Now we get just the two samples that we expect, TUMOR and NORMAL, in the header.

fixes https://github.com/hammerlab/biokepi/issues/204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/206)
<!-- Reviewable:end -->
