### PR TITLE
Expose a toolkit_install_path to run seq2HLA in conda environment

### DIFF
--- a/src/app/hla_typer.ml
+++ b/src/app/hla_typer.ml
@@ -17,8 +17,10 @@ let pipeline_to_json ppln =
 let pipeline_to_workflow ~work_dir ?(uri="/tmp/ht") ppln =
   let open Pipeline.Compiler in
   let machine =
-    let toolkit = Biopam.default ~install_path:(work_dir // "biopam") () in
-    Build_machine.create ~toolkit uri
+    let install_path = work_dir // "biopam" in
+    let toolkit_install_path = [`Biopam, install_path] in
+    let toolkit = Biopam.default ~install_path () in
+    Build_machine.create ~toolkit ~toolkit_install_path uri
   in
   let compiler =
     create ~processors:1

--- a/src/lib/build_machine.ml
+++ b/src/lib/build_machine.ml
@@ -10,7 +10,7 @@ let default_run_program : host:KEDSL.Host.t -> Make_fun.t =
 let create
     ?gatk_jar_location
     ?mutect_jar_location
-    ?run_program ?toolkit ?b37 uri =
+    ?run_program ?toolkit ?toolkit_install_path ?b37 uri =
   let open KEDSL in
   let host = Host.parse (uri // "ketrew_playground") in
   let meta_playground = Uri.of_string uri |> Uri.path in
@@ -35,5 +35,6 @@ let create
             ~destination_path:(meta_playground // "reference-genome"))
     ~host
     ~toolkit
+    ?toolkit_install_path
     ~run_program
     ~work_dir:(meta_playground // "work")

--- a/src/lib/build_machine.mli
+++ b/src/lib/build_machine.mli
@@ -20,6 +20,7 @@ val create :
   ?mutect_jar_location:(unit -> Tool_providers.broad_jar_location) ->
   ?run_program:Run_environment.Make_fun.t ->
   ?toolkit:Run_environment.Tool.Kit.t ->
+  ?toolkit_install_path:([`Biopam] * string) list ->
   ?b37:Reference_genome.t ->
   string ->
   Run_environment.Machine.t

--- a/src/lib/run_environment.ml
+++ b/src/lib/run_environment.ml
@@ -155,18 +155,20 @@ module Machine = struct
     toolkit: Tool.Kit.t;
     run_program: Make_fun.t;
     work_dir: string;
+    toolkit_install_path : ([`Biopam ] * string) list
   }
   let create
       ~host ~get_reference_genome ~toolkit
-      ~run_program ~work_dir  name =
+      ~run_program ~work_dir ?(toolkit_install_path=[]) name =
     {name; toolkit; get_reference_genome; host;
-     run_program; work_dir}
+     run_program; work_dir; toolkit_install_path}
 
   let name t = t.name
   let as_host t = t.host
   let get_reference_genome t = t.get_reference_genome
   let get_tool t =
     Tool.Kit.get_exn t.toolkit
+  let get_toolkit_path t k = List.assoc k t.toolkit_install_path
   let run_program t = t.run_program
 
   let quick_run_program t : Make_fun.t =

--- a/src/lib/seq2HLA.ml
+++ b/src/lib/seq2HLA.ml
@@ -5,8 +5,7 @@ module K = KEDSL
 
 let hla_type ?host ~work_dir ~run_with ~r1 ~r2 ~run_name =
   let tool = Machine.get_tool run_with (`Biopamed "seq2HLA") in
-  (* Why quote this here? Seems like it easy to create a bug,
-     why not enforce this at node construction ?*)
+  let install_path = Machine.get_toolkit_path run_with `Biopam in
   let r1pt = Filename.quote r1#product#path in
   let r2pt = Filename.quote r2#product#path in
   let name = sprintf "seq2HLA-%s" run_name in
@@ -15,7 +14,8 @@ let hla_type ?host ~work_dir ~run_with ~r1 ~r2 ~run_name =
       K.Program.(Tool.init tool
                 && exec ["mkdir"; "-p"; work_dir]
                 && exec ["cd"; work_dir]
-                && shf "seq2HLA -1 %s -2 %s -r %s" r1pt r2pt run_name)
+                && Conda.run_in_biokepi_env ~install_path
+                    (shf "seq2HLA -1 %s -2 %s -r %s" r1pt r2pt run_name))
   in
   let class1 = work_dir // (sprintf "%s-ClassI.HLAgenotype4digits" run_name) in
   let class2 = work_dir // (sprintf "%s-ClassII.HLAgenotype4digits" run_name) in


### PR DESCRIPTION
This PR enables the running of seq2HLA entirely inside of the biokepi conda environment. The problem that we experienced on demeter was due to `bowtie` itself being a python module (called via an env shebang) for argument processing. The problem was that if the default python wasn't compatible it would fail, while being called inside of `seq2HLA`. This presents two solutions:

1. Wrapping `bowtie` as well via `pyinstaller`, isolating its environment ... etc.
2. Giving up on that dream and exposing a working environment.

This PR takes the later approach. Certainly, the speed with which I am able to iterate on these tools is too slow for us to continue doing 1 for every tool. So an new approach is necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/207)
<!-- Reviewable:end -->
