### PR TITLE
Make `Conda` environment only “activable”

### DIFF
--- a/src/lib/biopam.mli
+++ b/src/lib/biopam.mli
@@ -40,9 +40,8 @@ type install_target = {
   edges : Common.KEDSL.workflow_edge list;
 
   (* Transform the install and init programs, e.g. it needs to be run in a
-     specific environment. Defaults to identity. *)
-  wrap_environment :
-    (Common.KEDSL.Program.t -> Common.KEDSL.Program.t) option;
+     specific environment. Defaults to a “no-op”. *)
+  init_environment : Common.KEDSL.Program.t option;
 }
 
 (** Provde the specified (via install_target) tool.*)

--- a/src/lib/conda.ml
+++ b/src/lib/conda.ml
@@ -15,7 +15,6 @@ let dir ~install_path = install_path // "conda_dir"
 let commands ~install_path com = dir ~install_path // "bin" // com
 let bin = commands "conda"
 let activate = commands "activate"
-let deactivate = commands "deactivate"
 
 (* give a conda command. *)
 let com ~install_path fmt =
@@ -124,7 +123,5 @@ let configured ?host ~install_path () =
     object method is_done = Some (`Command_returns (biokepi_env, 0)) end in
   workflow_node product ~make ~name:"Conda is configured." ~edges
 
-let run_in_biokepi_env ~install_path inside =
-  KEDSL.Program.(shf "source %s %s" (activate ~install_path) env_name
-                && inside
-                && shf "source %s" (deactivate ~install_path))
+let init_biokepi_env ~install_path  =
+  KEDSL.Program.(shf "source %s %s" (activate ~install_path) env_name)

--- a/src/lib/conda.mli
+++ b/src/lib/conda.mli
@@ -6,5 +6,4 @@ val configured : ?host:Common.KEDSL.Host.t -> install_path:string -> unit ->
   < is_done : Common.KEDSL.Condition.t option > Common.KEDSL.workflow_node
 
 (** A transform to run Programs with the Conda enviroment activated. *)
-val run_in_biokepi_env : install_path:string -> Common.KEDSL.Program.t ->
-  Common.KEDSL.Program.t
+val init_biokepi_env : install_path:string -> Common.KEDSL.Program.t


### PR DESCRIPTION
The function `wrap_environment` was working only because Conda's deactivation
doesn't really work (at least it seems so).

This is kind-of a different solution from #207.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/208)
<!-- Reviewable:end -->
