### PR TITLE
Make `reference_build` part of `bam_file`

### DIFF
--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -94,18 +94,33 @@ module KEDSL = struct
 
   type bam_file = <
     is_done: Ketrew_pure.Target.Condition.t option;
+    host: Host.t;
     path : string;
     sorting: [ `Coordinate | `Read_name ] option;
-    content_type: [ `DNA | `RNA ];
+    reference_build: string;
   >
-  let bam_file ?host ?sorting ?(contains=`DNA) path : bam_file =
+  let bam_file ~host ?sorting ~reference_build path : bam_file =
     object
-      val file = single_file ?host path
+      val file = single_file ~host path
+      method host = host
       method path = file#path
       method is_done = file#is_done
       method sorting = sorting
-      method content_type = contains
+      method reference_build = reference_build
     end
+
+  (** Make a new bam sharing most of the metadata. *)
+  let transform_bam ?change_sorting (bam : bam_file) ~path : bam_file =
+    bam_file
+      ~host:bam#host
+      ?sorting:(
+        match change_sorting with
+        | Some new_sorting -> Some new_sorting
+        | None -> bam#sorting
+      )
+      ~reference_build:bam#reference_build
+      path
+
 
   type bam_list = <
     is_done:  Ketrew_pure.Target.Condition.t option;

--- a/src/lib/mosaik.ml
+++ b/src/lib/mosaik.ml
@@ -99,7 +99,7 @@ let align
     | None -> mosaik_build_base_command  
   in   
   workflow_node ~name
-      (bam_file ~host:(Machine.(as_host run_with)) result)
+      (bam_file ~reference_build ~host:(Machine.(as_host run_with)) result)
       ~edges:[
         on_failure_activate (Remove.file ~run_with result);
         depends_on reference_fasta;

--- a/src/lib/muse.ml
+++ b/src/lib/muse.ml
@@ -32,10 +32,11 @@ module Configuration = struct
 end
 
 let run
-    ~reference_build ~configuration
+    ~configuration
     ~(run_with:Machine.t) ~normal ~tumor ~result_prefix ?(more_edges = []) how =
   let open KEDSL in
-  let reference = Machine.get_reference_genome run_with reference_build in
+  let reference =
+    Machine.get_reference_genome run_with normal#product#reference_build in
   let muse_tool = Machine.get_tool run_with Tool.Default.muse in
   let muse_call_on_region region =
     let result_file suffix =

--- a/src/lib/mutect.ml
+++ b/src/lib/mutect.ml
@@ -34,11 +34,12 @@ module Configuration = struct
 
 end
 
-let run ~reference_build
+let run
     ~(run_with:Machine.t) ~normal ~tumor ~result_prefix
     ?(more_edges = []) ~configuration how =
   let open KEDSL in
-  let reference = Machine.get_reference_genome run_with reference_build in
+  let reference =
+    Machine.get_reference_genome run_with normal#product#reference_build in
   let run_on_region ~add_edges region =
     let result_file suffix =
       let region_name = Region.to_filename region in

--- a/src/lib/somaticsniper.ml
+++ b/src/lib/somaticsniper.ml
@@ -7,7 +7,7 @@ open Workflow_utilities
 let default_prior_probability = 0.01
 let default_theta = 0.85
 
-let run ~reference_build
+let run
     ~run_with ?minus_T ?minus_s ~normal ~tumor ~result_prefix () =
   let open KEDSL in
   let name =
@@ -18,7 +18,7 @@ let run ~reference_build
   let result_file suffix = sprintf "%s-%s%s" result_prefix name suffix in
   let sniper = Machine.get_tool run_with Tool.Default.somaticsniper in
   let reference_fasta =
-    Machine.get_reference_genome run_with reference_build
+    Machine.get_reference_genome run_with normal#product#reference_build
     |> Reference_genome.fasta in
   let output_file = result_file "-snvs.vcf" in
   let run_path = Filename.dirname output_file in

--- a/src/lib/star.ml
+++ b/src/lib/star.ml
@@ -79,9 +79,9 @@ let align
   let base_star_target ~star_command = 
     workflow_node ~name
       (bam_file 
-        ?sorting:(Some `Coordinate)
-        ?contains:(Some `RNA)
+        ~sorting:`Coordinate
         ~host:(Machine.(as_host run_with)) 
+        ~reference_build
         result)
       ~edges:[
             on_failure_activate (Remove.file ~run_with result);

--- a/src/lib/strelka.ml
+++ b/src/lib/strelka.ml
@@ -119,7 +119,7 @@ module Configuration = struct
 end
 
 
-let run ~reference_build
+let run
     ~run_with ~normal ~tumor ~result_prefix ~processors ?(more_edges = [])
     ?(configuration = Configuration.default) () =
   let open KEDSL in
@@ -130,7 +130,8 @@ let run ~reference_build
   let config_file_path = result_file  "configuration" in
   let output_file_path = output_dir // "results/passed_somatic_combined.vcf" in
   let reference_fasta =
-    Machine.get_reference_genome run_with reference_build |> Reference_genome.fasta in
+    Machine.get_reference_genome run_with normal#product#reference_build
+    |> Reference_genome.fasta in
   let strelka_tool = Machine.get_tool run_with Tool.Default.strelka in
   let gatk_tool = Machine.get_tool run_with Tool.Default.gatk in
   let sorted_normal =

--- a/src/lib/stringtie.ml
+++ b/src/lib/stringtie.ml
@@ -16,7 +16,6 @@ module Configuration = struct
 end
 
 let run
-    ~reference_build
     ~configuration
     ~(run_with:Machine.t)
     ~processors
@@ -27,14 +26,13 @@ let run
   let result_file suffix = result_prefix ^ suffix in
   let output_dir = result_file "-stringtie_output" in
   let output_file_path = output_dir // "output.gtf" in
-  let reference_fasta =
-    Machine.get_reference_genome run_with reference_build
-    |> Reference_genome.fasta in
+  let reference_genome =
+    Machine.get_reference_genome run_with bam#product#reference_build in
+  let reference_fasta = Reference_genome.fasta reference_genome in
   let sorted_bam =
     Samtools.sort_bam_if_necessary ~run_with ~by:`Coordinate bam in
   let reference_annotations =
-    let genome = Machine.get_reference_genome run_with reference_build in
-    let gtf = Reference_genome.gtf genome in
+    let gtf = Reference_genome.gtf reference_genome in
     let use_the_gtf = configuration.Configuration.use_reference_gtf in
     match use_the_gtf, gtf with
     | true, Some some -> Some some
@@ -43,7 +41,7 @@ let run
       failwithf "Stringtie: use_reference_gtf is `true` but the genome %s \
                  does not provide one (use another genome or allow this to run \
                  without GTF by giving another Configuration.t)"
-        (Reference_genome.name genome)
+        (Reference_genome.name reference_genome)
   in
   let stringtie_tool = Machine.get_tool run_with Tool.Default.stringtie in
   let make =

--- a/src/lib/virmid.ml
+++ b/src/lib/virmid.ml
@@ -34,7 +34,7 @@ module Configuration = struct
 
 end
 
-let run ~reference_build
+let run
     ~run_with ~normal ~tumor ~result_prefix ~processors
     ?(more_edges = []) ~configuration () =
   let open KEDSL in
@@ -45,7 +45,8 @@ let run ~reference_build
   let output_prefix = "virmid-output" in
   let work_dir = result_file "-workdir" in
   let reference_fasta =
-    Machine.get_reference_genome run_with reference_build |> Reference_genome.fasta in
+    Machine.get_reference_genome run_with normal#product#reference_build
+    |> Reference_genome.fasta in
   let virmid_tool = Machine.get_tool run_with Tool.Default.virmid in
   let virmid_somatic_broken_vcf =
     (* maybe it's actually not broken, but later tools can be


### PR DESCRIPTION
This implements #24.

The function `KEDSL.transform_bam` also makes many workflows more readable and
safer.

We can later add a function `check_bams` that verifies at least one property: all the bams involved have the same ref-build (e.g. `normal` and `tumor` for variant callers; or the lists for bam-merging or indel-realigning).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/214)
<!-- Reviewable:end -->
