### PR TITLE
Improve the build of the documentation

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -63,19 +63,7 @@ build-all: lib-biokepi app-biokepi-demo \
 
 DOC_PACKAGES[] = $(LIB_PACKAGES)
 doc:
-    mkdir -p _build/apidoc/ && \
-    ocamlfind ocamldoc -html -d _build/apidoc/ -package $(concat \,, $(LIB_PACKAGES))  -thread \
-              -charset UTF-8 -t "Biokepi API" -keep-code -colorize-code \
-              -I _build/src/lib/  \
-              src/lib/* && \
-    INPUT=src  \
-        INDEX=README.md \
-        TITLE_PREFIX="Biokepi: " \
-        OUTPUT_DIR=_build/doc \
-        API=_build/apidoc/ \
-        CATCH_MODULE_PATHS='^(Biokepi[A-Z_a-z]+):', \
-        TITLE_SUBSTITUTIONS="main.ml:Literate Tests" \
-        oredoc
+    sh ./tools/build-doc.sh $(concat \,, $(LIB_PACKAGES))
 
 
 DIRS[] = src/lib

--- a/tools/build-doc.sh
+++ b/tools/build-doc.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+set -e
+LIB_PACKAGES=$1
+
+OCAMLDOC_OPTIONS="-package  $LIB_PACKAGES -thread -I _build/src/lib/ src/lib/*"
+OCAMLDOC_DOT_OPTIONS="-dot $OCAMLDOC_OPTIONS -dot-reduce"
+
+mkdir -p _build/apidoc/
+
+ocamlfind ocamldoc -html -d _build/apidoc/ $OCAMLDOC_OPTIONS \
+  -charset UTF-8 -t "Biokepi API" -keep-code -colorize-code
+
+ocamlfind ocamldoc -dot $OCAMLDOC_DOT_OPTIONS \
+  -o _build/apidoc/biokepi-all.dot \
+  -dot-include-all
+
+dot -x -Grotate=180 -v -Tsvg  -O _build/apidoc/biokepi-all.dot
+
+ocamlfind ocamldoc -dot $OCAMLDOC_DOT_OPTIONS \
+  -o _build/apidoc/biokepi.dot
+
+dot -x -Grotate=180 -v -Tsvg  -O _build/apidoc/biokepi.dot
+
+ocamlfind ocamldoc -dot $OCAMLDOC_DOT_OPTIONS -dot-types \
+  -o _build/apidoc/biokepi-types.dot
+
+dot -x -Grotate=180 -v -Tsvg  -O _build/apidoc/biokepi-types.dot
+
+generated_dot_md=_build/Module_Hierarchy.md
+cat <<EOBLOB > $generated_dot_md
+# Module Graphs
+
+Those graphs are the result of a transitive reduction of the selected
+dependency graph.
+
+## Biokepi Modules
+
+![biokepi](api/biokepi.dot.svg)
+
+## Biokepi Types
+
+![biokepi types](api/biokepi-types.dot.svg)
+
+
+## Including External
+
+This also shows modules from other libraries (like \`Ketrew\`,
+or \`ppx_deriving\`).
+
+![all](api/biokepi-all.dot.svg)
+
+
+EOBLOB
+
+INPUT=src,$generated_dot_md  \
+  INDEX=README.md \
+  TITLE_PREFIX="Biokepi: " \
+  OUTPUT_DIR=_build/doc \
+  API=_build/apidoc/ \
+  CATCH_MODULE_PATHS='^(Biokepi[A-Z_a-z]+):', \
+  TITLE_SUBSTITUTIONS="main.ml:Literate Tests" \
+  oredoc


### PR DESCRIPTION
This moves the build to the script `tools/build-doc.sh` to do the heavy duty.
It adds a webpage that includes 3 SVG dependency graphs from OCamlDoc's `-dot`
output.

<img width="1268" alt="screenshot 2016-03-31 13 22 36" src="https://cloud.githubusercontent.com/assets/617111/14184600/e96dc0ca-f743-11e5-9d1e-1583d972ceec.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/216)
<!-- Reviewable:end -->
