### PR TITLE
Adding Hisat2

### DIFF
--- a/src/lib/hisat.ml
+++ b/src/lib/hisat.ml
@@ -16,7 +16,8 @@ module Configuration = struct
         |`V_2_0_2_beta -> `String "V_2_0_2_beta"
       ;
     ]
-  let default = {name = "default"; version = `V_0_1_6_beta}
+  let default_v1 = {name = "default_v1"; version = `V_0_1_6_beta}
+  let default_v2 = {name = "default_v2"; version = `V_2_0_2_beta}
 end
 
 let index

--- a/src/lib/hisat.ml
+++ b/src/lib/hisat.ml
@@ -9,13 +9,21 @@ let index
   let reference_fasta =
     Machine.get_reference_genome run_with reference_build
       |> Reference_genome.fasta in
-  let hisat_tool = Machine.get_tool run_with Tool.Default.hisat in
-  let name =
-    sprintf "hisat-index-%s" (Filename.basename reference_fasta#product#path) in
-  let reference_dir = (Filename.dirname reference_fasta#product#path) in
-  let result_dir = sprintf "%s/hisat-index/" reference_dir in
-  let index_prefix = result_dir // "hisat-index" in
-  let first_index_file = sprintf "%s.1.bt2" index_prefix in
+  let result_dir = Filename.dirname index_prefix in
+  let version = configuration.Configuration.version in
+  let hisat_tool = Machine.get_tool run_with (`Hisat version) in
+  let build_binary = 
+    match version with
+    | `V_0_1_6_beta -> "hisat-build"
+    | `V_2_0_2_beta -> "hisat2-build"
+  in
+  let name = 
+    sprintf "%s-%s" build_binary (Filename.basename reference_fasta#product#path) in
+  let first_index_file = 
+    match version with
+      | `V_0_1_6_beta -> sprintf "%s.1.bt2" index_prefix
+      | `V_2_0_2_beta -> sprintf "%s.1.ht2" index_prefix 
+  in
   workflow_node ~name
     (single_file ~host:(Machine.(as_host run_with)) first_index_file)
     ~edges:[

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -158,7 +158,7 @@ module Construct = struct
 
   let star fastq = Star fastq
 
-  let hisat ?(configuration = Hisat.Configuration.default) fastq = Hisat(configuration, fastq)
+  let hisat ?(configuration = Hisat.Configuration.default_v1) fastq = Hisat(configuration, fastq)
 
   let stringtie ?(configuration = Stringtie.Configuration.default) bam =
     Stringtie (configuration, bam)

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -85,7 +85,7 @@ type _ t =
   | Gunzip_concat: fastq_gz t list -> fastq t
   | Concat_text: fastq t list -> fastq t
   | Star: fastq_sample t -> bam t
-  | Hisat: fastq_sample t -> bam t
+  | Hisat: Hisat.Configuration.t * fastq_sample t -> bam t
   | Stringtie: Stringtie.Configuration.t * bam t -> gtf t
   | Bwa: bwa_params * fastq_sample t -> bam t
   | Bwa_mem: bwa_params * fastq_sample t -> bam t
@@ -158,7 +158,7 @@ module Construct = struct
 
   let star fastq = Star fastq
 
-  let hisat fastq = Hisat fastq
+  let hisat ?(configuration = Hisat.Configuration.default) fastq = Hisat(configuration, fastq)
 
   let stringtie ?(configuration = Stringtie.Configuration.default) bam =
     Stringtie (configuration, bam)
@@ -371,10 +371,10 @@ let rec to_file_prefix:
         (to_file_prefix sample) gap_open_penalty gap_extension_penalty
     | Star (sample) ->
       sprintf "%s-star-aligned" (to_file_prefix sample)
-    | Hisat (sample) ->
-      sprintf "%s-hisat-aligned" (to_file_prefix sample)
+    | Hisat (conf, sample) ->
+      sprintf "%s-hisat-%s-aligned" (to_file_prefix sample) (conf.Hisat.Configuration.name)
     | Stringtie (conf, sample) ->
-      sprintf "%s-%sstringtie"
+      sprintf "%s-%s-stringtie"
         (to_file_prefix sample)
         (conf.Stringtie.Configuration.name)
     | Mosaik (sample) ->
@@ -445,9 +445,12 @@ let rec to_json: type a. a t -> json =
     | Star (input) ->
       let input_json = to_json input in
       call "STAR" [input_json]
-    | Hisat (input) ->
+    | Hisat (conf, input) ->
       let input_json = to_json input in
-      call "HISAT" [input_json]
+      call "HISAT" [
+        `Assoc ["configuration", Hisat.Configuration.to_json conf];
+        input_json;
+      ]
     | Stringtie (conf, input) ->
       let input_json = to_json input in
       call "Stringtie" [
@@ -745,11 +748,11 @@ module Compiler = struct
           ~make_workflow:(fun fastq ->
               Star.align ~reference_build ~processors
                 ~fastq ~result_prefix ~run_with:machine ())
-      | Hisat (what) ->
+      | Hisat (configuration, what) ->
         perform_aligner_parallelization
-          `Hisat ~make_aligner:(fun pe -> Hisat (pe)) what
+          `Hisat ~make_aligner:(fun pe -> Hisat (configuration, pe)) what
           ~make_workflow:(fun fastq ->
-              Hisat.align ~reference_build ~processors
+              Hisat.align ~configuration ~reference_build ~processors
                 ~fastq ~result_prefix ~run_with:machine ()
               |> Samtools.sam_to_bam ~reference_build ~run_with:machine
             )

--- a/src/lib/run_environment.ml
+++ b/src/lib/run_environment.ml
@@ -55,7 +55,7 @@ module Tool = struct
     let star = custom "star" ~version:"2.4.1d"
     let stringtie = custom "stringtie" ~version:"1.2.2"
     let cufflinks = custom "cufflinks" ~version:"2.2.1"
-    let hisat = `Hisat `V_2_0_2_beta
+    let hisat = `Hisat `V_0_1_6_beta
     let mosaik = custom "mosaik" ~version:"2.2.3"
     let kallisto = custom "kallisto" ~version:"0.42.3"
   end

--- a/src/lib/run_environment.ml
+++ b/src/lib/run_environment.ml
@@ -28,6 +28,7 @@ module Tool = struct
       [@@@ocaml.warning "-11"]
       type t = [
         | `Bwa of [ `V_0_7_10 ]
+        | `Hisat of [`V_0_1_6_beta | `V_2_0_2_beta]
         (* A tool that is installed by retrieving source or binary.*)
         | `Custom of string * string
         (* A tool that is installed via Biopam. *)
@@ -54,7 +55,7 @@ module Tool = struct
     let star = custom "star" ~version:"2.4.1d"
     let stringtie = custom "stringtie" ~version:"1.2.2"
     let cufflinks = custom "cufflinks" ~version:"2.2.1"
-    let hisat = custom "hisat" ~version:"0.1.6-beta"
+    let hisat = `Hisat `V_2_0_2_beta
     let mosaik = custom "mosaik" ~version:"2.2.3"
     let kallisto = custom "kallisto" ~version:"0.42.3"
   end

--- a/src/lib/tool_providers.ml
+++ b/src/lib/tool_providers.ml
@@ -111,12 +111,24 @@ let star_tool ~host ~meta_playground =
   Tool.create Tool.Default.star ~ensure 
     ~init:(Program.shf "export PATH=%s:$PATH" install_path)
 
-let hisat_tool ~host ~meta_playground =
+let hisat_tool ~version ~host ~meta_playground =
   let open KEDSL in
-  let install_path = meta_playground // "hisat" in
-  let url = "http://ccb.jhu.edu/software/hisat/downloads/hisat-0.1.6-beta-Linux_x86_64.zip" in
+  let url = 
+    match version with
+    | `V_0_1_6_beta -> "http://ccb.jhu.edu/software/hisat/downloads/hisat-0.1.6-beta-Linux_x86_64.zip"
+    | `V_2_0_2_beta -> "ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.0.2-beta-Linux_x86_64.zip"
+  in
+  let install_path = 
+   match version with
+    | `V_0_1_6_beta ->  meta_playground // "hisat-V_0_1_6" 
+    | `V_2_0_2_beta ->  meta_playground // "hisat-V_2_0_2"
+  in
   let archive = Filename.basename url in
-  let hisat_binary = "hisat" in
+  let hisat_binary = 
+    match version with
+    | `V_0_1_6_beta -> "hisat"
+    | `V_2_0_2_beta -> "hisat2"
+  in
   let ensure =
     workflow_node (single_file ~host (install_path // hisat_binary))
       ~name:(sprintf "Install HISAT")
@@ -130,12 +142,12 @@ let hisat_tool ~host ~meta_playground =
             && shf "cd %s" install_path
             && Workflow_utilities.Download.wget_program url
             && shf "unzip %s" archive
-            && sh "cd hisat-*"
+            && sh "cd hisat*"
             && sh "mv hisat* ../"
             && sh "echo Done"
           ))
   in
-  Tool.create Tool.Default.hisat ~ensure 
+  Tool.create (`Hisat version) ~ensure 
     ~init:(Program.shf "export PATH=%s:$PATH" install_path)
 
 let kallisto_tool ~host ~meta_playground =
@@ -494,7 +506,7 @@ let default_toolkit
     star_tool ~host ~meta_playground;
     stringtie_tool ~host ~meta_playground;
     cufflinks_tools ~host ~meta_playground;
-    hisat_tool ~host ~meta_playground;
+    hisat_tool ~host ~meta_playground ~version:`V_0_1_6_beta;
     mosaik_tool ~host ~meta_playground;
     kallisto_tool ~host ~meta_playground;
   ]

--- a/src/lib/tool_providers.ml
+++ b/src/lib/tool_providers.ml
@@ -507,6 +507,7 @@ let default_toolkit
     stringtie_tool ~host ~meta_playground;
     cufflinks_tools ~host ~meta_playground;
     hisat_tool ~host ~meta_playground ~version:`V_0_1_6_beta;
+    hisat_tool ~host ~meta_playground ~version:`V_2_0_2_beta;
     mosaik_tool ~host ~meta_playground;
     kallisto_tool ~host ~meta_playground;
   ]


### PR DESCRIPTION
This has been tested insofar in that it correctly produces the index and proper hisat2 command (alongside with hisat1) but the hisat2 alignment has not completed. I figured it was worth reviewing in the meantime

This follows the model we discussed previously:
- Creates a versioned Hisat in `run_environment.ml`
- Add a version argument to `hisat` in `tool_providers.ml` as well as putting the version in the install path
- Adds config to hisat to switch between versions

Let me know any critiques or if anything can be improved.

cc @smondet @ihodes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/219)
<!-- Reviewable:end -->
