### PR TITLE
TTFI Pipeline -- First Blood

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -76,6 +76,7 @@ section # Executable tests
     OCAMLPACKS[] = $(LIB_PACKAGES)
     OCamlProgramOfFile(biokepi-tests, $(file src/test/main.ml))
     OCamlProgramOfFile(biokepi-test-all-downloads, $(file src/test/all_downloads.ml))
+    OCamlProgramOfFile(biokepi-test-ttfi-pipeline, $(file src/test/ttfi_pipeline.ml))
     OCamlProgramOfFile(biokepi-hla-typer, $(file src/app/hla_typer.ml))
 
 
@@ -101,7 +102,8 @@ build-all: lib-biokepi_run_environment \
            lib-biokepi_pipeline_edsl \
            lib-biokepi \
            app-biokepi-demo \
-           app-biokepi-tests app-biokepi-test-all-downloads app-biokepi-hla-typer
+           app-biokepi-tests app-biokepi-test-all-downloads \
+           app-biokepi-hla-typer  app-biokepi-test-ttfi-pipeline
 
 .PHONY: doc
 

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -1,6 +1,16 @@
 
 module Pipeline = Biokepi_pipeline_edsl.Pipeline
 
+module EDSL = struct
+
+  module type Semantics = Biokepi_pipeline_edsl.Semantics.Bioinformatics_base
+
+  module Compile = struct
+    module To_display = Biokepi_pipeline_edsl.To_display
+  end
+
+end
+
 module KEDSL = Biokepi_run_environment.Common.KEDSL
 
 module Metadata = Biokepi_run_environment.Metadata

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -7,6 +7,7 @@ module EDSL = struct
 
   module Compile = struct
     module To_display = Biokepi_pipeline_edsl.To_display
+    module To_workflow = Biokepi_pipeline_edsl.To_workflow
   end
 
 end

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -1,0 +1,73 @@
+
+module type Lambda_calculus = sig
+  type 'a repr  (* representation type *)
+
+  (* lambda abstract *)
+  val lambda : ('a repr -> 'b repr) -> ('a -> 'b) repr
+  (* application *)
+  val apply : ('a -> 'b) repr -> 'a repr -> 'b repr
+
+  type 'a observation
+  val observe : (unit -> 'a repr) -> 'a observation
+end
+
+module type Lambda_with_list_operations = sig
+  include Lambda_calculus
+  module List_repr: sig
+    val make: ('a repr) list -> 'a list repr
+    val map: ('a list repr) -> f:('a -> 'b) repr -> ('b list repr)
+  end
+end
+
+(* this should move to the Bwa module *)
+type bwa_params = {
+  gap_open_penalty: int;
+  gap_extension_penalty: int;
+}
+
+
+module type Bioinformatics_base = sig
+
+  include Lambda_with_list_operations
+
+  val fastq : 
+    sample_name : string ->
+    ?fragment_id : string ->
+    r1: string ->
+    ?r2: string ->
+    unit -> [ `Fastq ] repr
+
+  val fastq_gz:
+    sample_name : string ->
+    ?fragment_id : string ->
+    r1: string -> ?r2: string ->
+    unit -> [ `Gz of [ `Fastq ] ] repr
+
+  val bam :
+    path : string ->
+    ?sorting: [ `Coordinate | `Read_name ] ->
+    reference_build: string ->
+    unit -> [ `Bam ] repr
+
+  val bwa_aln:
+    ?configuration: bwa_params ->
+    [ `Fastq ] repr ->
+    [ `Bam ] repr
+
+  val gunzip: [ `Gz of 'a] repr -> 'a repr
+
+  val gunzip_concat: ([ `Gz of 'a] list) repr -> 'a repr
+
+  val concat: ('a list) repr -> 'a repr
+
+
+  val merge_bams: ([ `Bam ] list) repr -> [ `Bam ] repr
+
+  val mutect:
+    configuration: Biokepi_bfx_tools.Mutect.Configuration.t ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+end
+

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -19,13 +19,6 @@ module type Lambda_with_list_operations = sig
   end
 end
 
-(* this should move to the Bwa module *)
-type bwa_params = {
-  gap_open_penalty: int;
-  gap_extension_penalty: int;
-}
-
-
 module type Bioinformatics_base = sig
 
   include Lambda_with_list_operations
@@ -50,7 +43,8 @@ module type Bioinformatics_base = sig
     unit -> [ `Bam ] repr
 
   val bwa_aln:
-    ?configuration: bwa_params ->
+    ?configuration: Biokepi_bfx_tools.Bwa.Configuration.Aln.t ->
+    reference_build: Biokepi_run_environment.Reference_genome.name ->
     [ `Fastq ] repr ->
     [ `Bam ] repr
 

--- a/src/pipeline_edsl/to_display.ml
+++ b/src/pipeline_edsl/to_display.ml
@@ -1,0 +1,109 @@
+
+open Nonstd
+
+module SP = SmartPrint
+module OCaml = SmartPrint.OCaml
+let entity sp = SP.(nest (parens  (sp)))
+
+type 'a repr = var_count: int -> SP.t
+
+type 'a observation = SP.t
+
+let lambda f =
+  fun ~var_count ->
+    let var_name = sprintf "var%d" var_count in
+    let var_repr = fun ~var_count -> SP.string var_name in
+    let applied = f var_repr ~var_count:(var_count + 1) in
+    entity SP.(string "λ" ^^ string var_name ^^ string "→" ^^ applied)
+
+let apply f v =
+  fun ~var_count ->
+    entity (SP.separate SP.space [f ~var_count; v ~var_count])
+
+let observe f = f () ~var_count:0
+
+module List_repr = struct
+  let make l =
+    fun ~var_count ->
+      SP.nest (OCaml.list (fun a -> a ~var_count) l)
+
+  let map l ~f =
+    let open SP in
+    fun ~var_count ->
+      entity (
+        string "List.map"
+        ^^ nest (string "~f:" ^^ f ~var_count)
+        ^^ l ~var_count
+      )
+end
+
+let input_value name kv =
+  let open SP in
+  fun ~var_count ->
+    entity (
+      ksprintf string "input-%s" name
+      ^^ (OCaml.list 
+                 (fun (k, v) -> parens (string k ^-^ string ":" ^^ string v))
+                 kv)
+    )
+
+let function_call name params =
+  let open SP in
+  entity (
+    ksprintf string "%s" name
+    ^^ (OCaml.list
+               (fun (k, v) -> parens (string k ^-^ string ":" ^^ v))
+               params)
+  )
+
+let fastq
+  ~sample_name ?fragment_id ~r1 ?r2 () =
+  input_value "fastq" [
+    "sample_name", sample_name;
+    "fragment_id", Option.value ~default:"NONE" fragment_id;
+    "R1", r1;
+    "R2", Option.value ~default:"NONE" r2;
+  ]
+
+let fastq_gz
+  ~sample_name ?fragment_id ~r1 ?r2 () =
+  input_value "fastq.gz" [
+    "sample_name", sample_name;
+    "fragment_id", Option.value ~default:"NONE" fragment_id;
+    "R1", r1;
+    "R2", Option.value ~default:"NONE" r2;
+  ]
+
+let bam ~path ?sorting ~reference_build () =
+  input_value "bam" [
+    "path", path;
+    "sorting",
+    Option.value_map ~default:"NONE" sorting
+      ~f:(function `Coordinate -> "Coordinate" | `Read_name -> "Read-name");
+    "reference_build", reference_build;
+  ]
+
+
+let bwa_aln ?configuration fq ~var_count =
+  let fq_compiled = fq ~var_count in
+  function_call "bwa-aln" ["input", fq_compiled]
+
+let gunzip gz ~var_count =
+  function_call "gunzip" ["input", gz ~var_count]
+
+let gunzip_concat gzl ~var_count =
+  function_call "gunzip-concat" ["input-list", gzl ~var_count]
+
+let concat l ~var_count =
+  function_call "concat" ["input-list", l ~var_count]
+
+let merge_bams bl ~var_count =
+  function_call "merge-bams" ["input-list", bl ~var_count]
+
+let mutect ~configuration ~normal ~tumor ~var_count =
+  function_call "mutect" [
+    "configuration", SP.string  
+      configuration.Biokepi_bfx_tools.Mutect.Configuration.name;
+    "normal", normal ~var_count;
+    "tumor", tumor ~var_count;
+  ]

--- a/src/pipeline_edsl/to_display.ml
+++ b/src/pipeline_edsl/to_display.ml
@@ -1,6 +1,8 @@
 
 open Nonstd
 
+module Tools = Biokepi_bfx_tools
+
 module SP = SmartPrint
 module OCaml = SmartPrint.OCaml
 let entity sp = SP.(nest (parens  (sp)))
@@ -84,9 +86,16 @@ let bam ~path ?sorting ~reference_build () =
   ]
 
 
-let bwa_aln ?configuration fq ~var_count =
+let bwa_aln
+    ?(configuration = Tools.Bwa.Configuration.Aln.default)
+    ~reference_build fq ~var_count =
   let fq_compiled = fq ~var_count in
-  function_call "bwa-aln" ["input", fq_compiled]
+  function_call "bwa-aln" [
+    "configuration",
+    Tools.Bwa.Configuration.Aln.name configuration |> SP.string;
+    "reference_build", SP.string reference_build;
+    "input", fq_compiled;
+  ]
 
 let gunzip gz ~var_count =
   function_call "gunzip" ["input", gz ~var_count]
@@ -103,7 +112,7 @@ let merge_bams bl ~var_count =
 let mutect ~configuration ~normal ~tumor ~var_count =
   function_call "mutect" [
     "configuration", SP.string  
-      configuration.Biokepi_bfx_tools.Mutect.Configuration.name;
+      configuration.Tools.Mutect.Configuration.name;
     "normal", normal ~var_count;
     "tumor", tumor ~var_count;
   ]

--- a/src/pipeline_edsl/to_display.mli
+++ b/src/pipeline_edsl/to_display.mli
@@ -1,0 +1,8 @@
+(** Compiler from EDSL representations to {!SmartPrint.t} pretty printing. *)
+
+include
+  Semantics.Bioinformatics_base
+  with type 'a repr = var_count: int -> SmartPrint.t
+   and
+   type 'a observation = SmartPrint.t
+

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -1,0 +1,205 @@
+open Nonstd
+let (//) = Filename.concat
+
+module File_type_specification = struct
+  open Biokepi_run_environment.Common.KEDSL
+
+  type 'a t = ..
+  type 'a t +=
+    | Fastq: fastq_reads workflow_node -> [ `Fastq ] t
+    | Bam: bam_file workflow_node -> [ `Bam ] t
+    | Vcf: single_file workflow_node -> [ `Vcf ] t
+    | Gz: 'a t -> [ `Gz of 'a ] t
+    | List: 'a t list -> 'a list t
+    | Lambda: ('a t -> 'b t) -> ('a -> 'b) t
+
+  let fail_get name =
+    ksprintf failwith "Error while extracting File_type_specification.t \
+                       (%s case), this usually means that the type has been \
+                       wrongly extended, and provides more than one \
+                       [ `%s ] t case" name name
+
+  let get_fastq : [ `Fastq ] t -> fastq_reads workflow_node = function
+  | Fastq b -> b
+  | _ -> fail_get "Fastq"
+
+  let get_bam : [ `Bam ] t -> bam_file workflow_node = function
+  | Bam b -> b
+  | _ -> fail_get "Bam"
+
+  let get_vcf : [ `Vcf ] t -> single_file workflow_node = function
+  | Vcf v -> v
+  | _ -> fail_get "Vcf"
+
+  let get_gz : [ `Gz of 'a ] t -> 'a t = function
+  | Gz v -> v
+  | _ -> fail_get "Gz"
+end
+
+open Biokepi_run_environment
+
+module type Compiler_configuration = sig
+  val processors : int
+  val work_dir: string
+  val machine : Machine.t
+end
+
+module Make (Config : Compiler_configuration) 
+    : Semantics.Bioinformatics_base
+    with type 'a repr = 'a File_type_specification.t and
+    type 'a observation = 'a File_type_specification.t
+= struct
+  open File_type_specification
+  module Tools = Biokepi_bfx_tools
+  module KEDSL = Common.KEDSL
+
+  type 'a repr = 'a t 
+  type 'a observation = 'a repr
+
+  let observe : (unit -> 'a repr) -> 'a observation = fun f -> f ()
+
+  let lambda : ('a repr -> 'b repr) -> ('a -> 'b) repr = fun f ->
+    Lambda f
+
+  let apply : ('a -> 'b) repr -> 'a repr -> 'b repr = fun f_repr x ->
+    match f_repr with
+    | Lambda f -> f x
+    | _ -> assert false
+
+  module List_repr = struct
+    let make : 'a repr list -> 'a list repr = fun l -> List l
+    let map : 'a list repr -> f:('a -> 'b) repr -> 'b list repr = fun l ~f ->
+      match l with
+      | List l ->
+        List (List.map ~f:(fun v -> apply f v) l)
+      | _ -> assert false
+  end
+
+  let host = Machine.as_host Config.machine
+  let run_with = Config.machine
+
+  let fastq
+      ~sample_name ?fragment_id ~r1 ?r2 () =
+    Fastq (
+      KEDSL.workflow_node (KEDSL.fastq_reads ~host ~name:sample_name r1 r2)
+        ~name:(sprintf "Input-fastq: %s (%s)" sample_name 
+                 (Option.value fragment_id ~default:(Filename.basename r1)))
+    )
+
+  let fastq_gz
+      ~sample_name ?fragment_id ~r1 ?r2 () =
+    Gz (
+      Fastq (
+        KEDSL.workflow_node (KEDSL.fastq_reads ~host ~name:sample_name r1 r2)
+          ~name:(sprintf "Input-fastq-gz: %s (%s)" sample_name 
+                   (Option.value fragment_id ~default:(Filename.basename r1)))
+      )
+    )
+
+  let bam ~path ?sorting ~reference_build () =
+    Bam (
+      KEDSL.workflow_node
+        (KEDSL.bam_file ~host ?sorting ~reference_build path)
+        ~name:(sprintf "Input-bam: %s" (Filename.basename path))
+    )
+
+  let bwa_aln
+      ?(configuration = Tools.Bwa.Configuration.Aln.default)
+      ~reference_build fq =
+    let freads = get_fastq fq in
+    let result_prefix =
+      Config.work_dir // 
+      sprintf "%s-%s_bwa-%s"
+        freads#product#escaped_sample_name
+        (Option.value freads#product#fragment_id ~default:"")
+        (Tools.Bwa.Configuration.Aln.name configuration)
+    in
+    Bam (
+      Tools.Bwa.align_to_sam ~reference_build ~processors:Config.processors
+        ~configuration
+        ~fastq:freads
+        ~result_prefix ~run_with ()
+      |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
+    )
+
+  let gunzip: type a. [ `Gz of a ] t -> a t = fun gz ->
+    let open KEDSL in
+    let inside = get_gz gz in
+    begin match inside with
+    | Fastq f ->
+      let make_result_path read =
+        let base = Filename.basename read in
+        Config.work_dir //
+        (match base with
+        | fastqgz when Filename.check_suffix base ".fastq.gz" ->
+          Filename.chop_suffix base ".gz"
+        | fqz when Filename.check_suffix base ".fqz" ->
+          Filename.chop_suffix base ".fqz" ^ ".fastq"
+        | other ->
+          ksprintf failwith "To_workflow.gunzip: cannot recognize Gz-Fastq \
+                             extension: %S" other)
+      in
+      let gunzip read =
+        let result_path = make_result_path read#product#path in
+        Workflow_utilities.Gunzip.concat
+          ~run_with [read] ~result_path in
+      let fastq_r1 = gunzip f#product#r1 in
+      let fastq_r2 = Option.map f#product#r2 ~f:gunzip in
+      let product =
+        let r2 = Option.map fastq_r2 ~f:(fun r -> r#product#path) in
+        fastq_reads ~host
+          ~name:f#product#sample_name
+          ?fragment_id:f#product#fragment_id
+          fastq_r1#product#path r2
+      in
+      let edges =
+        match fastq_r2 with
+        | Some r2 -> [depends_on fastq_r1; depends_on r2]
+        | None -> [depends_on fastq_r1]
+      in
+      Fastq (
+        workflow_node product
+          ~name:(sprintf "Gunzipped-fastq: %s (%s)" 
+                   f#product#sample_name 
+                   (Option.value f#product#fragment_id
+                      ~default:(Filename.basename fastq_r1#product#path)))
+          ~edges
+      )
+    | other ->
+      ksprintf failwith "To_workflow.gunzip: non-FASTQ input not implemented"
+    end
+
+  let gunzip_concat gzl =
+    ksprintf failwith "To_workflow.gunzip_concat: not implemented"
+
+  let concat l =
+    ksprintf failwith "To_workflow.concat: not implemented"
+
+  let merge_bams: [ `Bam ] list t -> [ `Bam ] t =
+    function
+    | List bam_files ->
+      let bams = List.map bam_files ~f:get_bam in
+      let output_path =
+        let one = List.hd_exn bams in
+        Filename.chop_extension one#product#path
+        ^ sprintf "-merged-%s.bam"
+          (List.map bams ~f:(fun bam -> bam#product#path)
+           |> String.concat ""
+           |> Digest.string |> Digest.to_hex)
+      in
+      Bam (Tools.Samtools.merge_bams ~run_with bams output_path)
+    | other ->
+      fail_get "To_workflow.merge_bams: not a list of bams?"
+
+  let mutect ~configuration ~normal ~tumor =
+    let normal_bam = get_bam normal in
+    let tumor_bam = get_bam tumor in
+    let result_prefix =
+      Filename.chop_extension tumor_bam#product#path
+      ^ sprintf "_mutect-%s" (configuration.Tools.Mutect.Configuration.name)
+    in
+    Vcf (
+      Tools.Mutect.run ~configuration ~run_with
+        ~normal:normal_bam ~tumor:tumor_bam
+        ~result_prefix `Map_reduce)
+end

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -74,8 +74,9 @@ module KEDSL = struct
     paths : string * (string option);
     sample_name: string;
     escaped_sample_name: string;
+    fragment_id: string option;
   >
-  let fastq_reads ?host ?name r1 r2_opt : fastq_reads =
+  let fastq_reads ?host ?name ?fragment_id r1 r2_opt : fastq_reads =
     object (self)
       val r1_file = single_file ?host r1
       val r2_file_opt = Option.map r2_opt ~f:(single_file ?host)
@@ -86,6 +87,7 @@ module KEDSL = struct
           | None -> `And [r1_file#exists; r1_file#exists;])
       method sample_name =
         Option.value name ~default:(Filename.basename r1)
+      method fragment_id = fragment_id
       method escaped_sample_name =
         String.map self#sample_name ~f:(function
           | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' | '-' | '_' as c -> c

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -72,6 +72,8 @@ module KEDSL = struct
   type fastq_reads = <
     is_done: Ketrew_pure.Target.Condition.t option;
     paths : string * (string option);
+    r1 : single_file workflow_node;
+    r2 : single_file workflow_node option;
     sample_name: string;
     escaped_sample_name: string;
     fragment_id: string option;
@@ -80,6 +82,11 @@ module KEDSL = struct
     object (self)
       val r1_file = single_file ?host r1
       val r2_file_opt = Option.map r2_opt ~f:(single_file ?host)
+      method r1 =
+        workflow_node r1_file
+      method r2 = 
+        Option.map r2_file_opt ~f:(fun r2_file ->
+            workflow_node r2_file)
       method paths = (r1, r2_opt)
       method is_done =
         Some (match r2_file_opt with

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -1,0 +1,60 @@
+(** This test uses the high-level EDSL and tries different compilation targets,
+    but does not produce runnable workflows. *)
+open Nonstd
+
+module Pipeline_1 (Bfx : Biokepi.EDSL.Semantics) = struct
+
+  let fastq_list ~dataset files =
+    List.map files ~f:begin function
+    | `Pair (r1, r2) ->
+      if Filename.check_suffix r1 ".gz"
+      || Filename.check_suffix r1 ".fqz"
+      then
+        Bfx.(fastq_gz ~sample_name:dataset ~r1 ~r2 () |> gunzip)
+      else
+        Bfx.(fastq ~sample_name:dataset ~r1 ~r2 ())
+    end
+    |> Bfx.List_repr.make
+
+
+  let mutect_on_fastqs ~normal ~tumor =
+    let align_list list_of_fastqs =
+      Bfx.List_repr.map list_of_fastqs ~f:(Bfx.lambda (fun fq -> Bfx.bwa_aln fq))
+      |> Bfx.merge_bams
+    in
+    Bfx.mutect
+      ~configuration:Biokepi.Tools.Mutect.Configuration.default
+      ~normal:(align_list normal)
+      ~tumor:(align_list tumor)
+
+  let run ~normal ~tumor =
+    Bfx.observe (fun () ->
+        mutect_on_fastqs
+          ~normal:(fastq_list ~dataset:(fst normal) (snd normal))
+          ~tumor:(fastq_list ~dataset:(fst tumor) (snd tumor))
+      )
+
+end
+
+let normal_1 = 
+  ("normal-1", [
+      `Pair ("normal-1-001-r1.fastq", "normal-1-001-r2.fastq"); 
+      `Pair ("normal-1-002-r1.fastq", "normal-1-002-r2.fastq"); 
+      `Pair ("normal-1-003-r1.fqz", "normal-1-003-r2.fqz"); 
+    ])
+
+let tumor_1 = 
+  ("tumor-1", [
+      `Pair ("tumor-1-001-r1.fastq.gz", "tumor-1-001-r2.fastq.gz"); 
+      `Pair ("tumor-1-002-r1.fastq.gz", "tumor-1-002-r2.fastq.gz"); 
+      `Pair ("tumor-1-003-r1.fastq.gz", "tumor-1-003-r2.fastq.gz"); 
+    ])
+
+let () =
+  let module Display_pipeline_1 =
+    Pipeline_1(Biokepi.EDSL.Compile.To_display)
+  in
+  printf "Pipeline 1:\n\n%s\n\n%!"
+    (Display_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1
+     |> SmartPrint.to_string 80 2)
+


### PR DESCRIPTION

This is the beginning of the implementation of the Typed-Tagless-Final-Interpreter -based pipeline EDSL.

It is far from ready for use but since there are some changes in `Common` and `Bwa` it's nice to get it merged.

It makes also a smaller peer review :)

Names may still change, open to suggestions (e.g. `Biokepi.EDSL` → that's maybe not specific enough?).

For now there is:

- `Semantics`: module type that defines the EDSL.
- `To_display` interpreter that compiles to `SmartPrint.t`
- `To_workflow`: interpreter that compiles to Ketrew workflows (of `Biokepi.Tools.*` nodes)
- `src/test/ttfi_pipeline.ml`: a test that will grow more and more complex pipelines

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/233)
<!-- Reviewable:end -->
