### PR TITLE
TTFI-pipeline: 2nd strike

### DIFF
--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -14,6 +14,13 @@ module EDSL = struct
        and
        type 'a observation = Yojson.Basic.json =
       Biokepi_pipeline_edsl.To_json
+
+    module To_dot : Semantics.Bioinformatics_base
+      with 
+        (* type 'a repr = var_count: int -> Yojson.Basic.json *)
+       (* and *)
+       type 'a observation = string =
+      Biokepi_pipeline_edsl.To_dot
   end
 
 end

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -23,6 +23,12 @@ module EDSL = struct
       Biokepi_pipeline_edsl.To_dot
   end
 
+  module Transform = struct
+
+    module Beta_reduce = Biokepi_pipeline_edsl.Transform_applications.Make
+
+  end
+
 end
 
 module KEDSL = Biokepi_run_environment.Common.KEDSL

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -25,7 +25,7 @@ module EDSL = struct
 
   module Transform = struct
 
-    module Beta_reduce = Biokepi_pipeline_edsl.Transform_applications.Make
+    module Apply_functions = Biokepi_pipeline_edsl.Transform_applications.Make
 
   end
 

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -8,6 +8,12 @@ module EDSL = struct
   module Compile = struct
     module To_display = Biokepi_pipeline_edsl.To_display
     module To_workflow = Biokepi_pipeline_edsl.To_workflow
+
+    module To_json : Semantics.Bioinformatics_base
+      with type 'a repr = var_count: int -> Yojson.Basic.json
+       and
+       type 'a observation = Yojson.Basic.json =
+      Biokepi_pipeline_edsl.To_json
   end
 
 end

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -17,15 +17,13 @@ module EDSL = struct
 
     module To_dot : Semantics.Bioinformatics_base
       with 
-        (* type 'a repr = var_count: int -> Yojson.Basic.json *)
-       (* and *)
        type 'a observation = string =
       Biokepi_pipeline_edsl.To_dot
   end
 
   module Transform = struct
 
-    module Apply_functions = Biokepi_pipeline_edsl.Transform_applications.Make
+    module Apply_functions = Biokepi_pipeline_edsl.Transform_applications.Apply
 
   end
 

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -1,0 +1,88 @@
+
+(**
+QueL-like Compiler Optimization Framework
+  
+
+This is “stolen” from ["quel_o.ml"] …
+i.e. the “Query optimization framework in tagless-final.”
+
+The code is reusable for any optimization pass.
+
+*)
+
+module type Trans_base = sig
+  type 'a from
+  type 'a term
+  val fwd : 'a from -> 'a term (* reflection *)
+  val bwd : 'a term -> 'a from (* reification *)
+end
+
+module type Transformation = sig
+  include Trans_base
+  val fmap  : ('a from -> 'b from) -> ('a term -> 'b term)
+  val fmap2 : ('a from -> 'b from -> 'c from) ->
+    ('a term -> 'b term -> 'c term)
+end
+
+(** Add the default implementations of the mapping functions *)
+module Define_transformation(X : Trans_base) = struct
+  include X
+  let fmap  f term        = fwd (f (bwd term))
+  let fmap2 f term1 term2 = fwd (f (bwd term1) (bwd term2))
+end
+
+(** The default, generic optimizer
+   Concrete optimizers are built by overriding the interpretations
+   of some DSL forms.
+*)
+module Generic_optimizer
+    (X: Transformation)
+    (Input: Semantics.Bioinformatics_base with type 'a repr = 'a X.from)
+  : Semantics.Bioinformatics_base
+    with type 'a repr = 'a X.term
+     and type 'a observation = 'a Input.observation
+= struct
+  module Tools = Biokepi_bfx_tools
+  open X
+  type 'a repr = 'a term
+  type 'a observation  = 'a Input.observation
+
+  let lambda f = fwd (Input.lambda (fun x -> bwd (f (fwd x))))
+  let apply e1 e2 = fmap2 Input.apply e1 e2
+  let observe f =
+    Input.observe (fun () -> bwd (f ()))
+
+  module List_repr = struct
+    let make l =
+      fwd (Input.List_repr.make (List.map bwd l))
+    let map l ~f =
+      fwd (Input.List_repr.map (bwd l) (bwd f))
+  end
+
+  let fastq ~sample_name ?fragment_id ~r1 ?r2 () =
+    fwd (Input.fastq ~sample_name ?fragment_id ~r1 ?r2 ())
+
+  let fastq_gz ~sample_name ?fragment_id ~r1 ?r2 () =
+    fwd (Input.fastq_gz ~sample_name ?fragment_id ~r1 ?r2 ())
+
+  let bam ~path ?sorting ~reference_build () =
+    fwd (Input.bam ~path ?sorting ~reference_build ())
+
+  let bwa_aln ?configuration ~reference_build fq =
+    fwd (Input.bwa_aln ?configuration ~reference_build (bwd fq))
+  let gunzip gz =
+    fwd (Input.gunzip (bwd gz))
+
+  let gunzip_concat gzl =
+    fwd (Input.gunzip_concat (bwd gzl))
+
+  let concat l =
+    fwd (Input.concat (bwd l))
+
+  let merge_bams bl =
+    fwd (Input.merge_bams (bwd bl))
+
+  let mutect ~configuration ~normal ~tumor =
+    fwd (Input.mutect ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+
+end

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -1,12 +1,12 @@
 
 (**
-QueL-like Compiler Optimization Framework
-  
+   QueL-like Compiler Optimization Framework
 
-This is “stolen” from ["quel_o.ml"] …
-i.e. the “Query optimization framework in tagless-final.”
 
-The code is reusable for any optimization pass.
+   This is “stolen” from ["quel_o.ml"] …
+   i.e. the “Query optimization framework in tagless-final.”
+
+   The code is reusable for any optimization pass.
 
 *)
 
@@ -31,9 +31,12 @@ module Define_transformation(X : Trans_base) = struct
   let fmap2 f term1 term2 = fwd (f (bwd term1) (bwd term2))
 end
 
-(** The default, generic optimizer
-   Concrete optimizers are built by overriding the interpretations
-   of some DSL forms.
+(** The default, generic optimizer.
+
+    Concrete optimizers are built by overriding the interpretations
+    of some DSL forms.
+
+    See the module {!Transform_applications} for an example of use.
 *)
 module Generic_optimizer
     (X: Transformation)

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -52,12 +52,10 @@ module Generic_optimizer
   let observe f =
     Input.observe (fun () -> bwd (f ()))
 
-  module List_repr = struct
-    let make l =
-      fwd (Input.List_repr.make (List.map bwd l))
-    let map l ~f =
-      fwd (Input.List_repr.map (bwd l) (bwd f))
-  end
+  let list l =
+    fwd (Input.list (List.map bwd l))
+  let list_map l ~f =
+    fwd (Input.list_map (bwd l) (bwd f))
 
   let fastq ~sample_name ?fragment_id ~r1 ?r2 () =
     fwd (Input.fastq ~sample_name ?fragment_id ~r1 ?r2 ())

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -13,10 +13,8 @@ end
 
 module type Lambda_with_list_operations = sig
   include Lambda_calculus
-  module List_repr: sig
-    val make: ('a repr) list -> 'a list repr
-    val map: ('a list repr) -> f:('a -> 'b) repr -> ('b list repr)
-  end
+  val list: ('a repr) list -> 'a list repr
+  val list_map: ('a list repr) -> f:('a -> 'b) repr -> ('b list repr)
 end
 
 module type Bioinformatics_base = sig

--- a/src/pipeline_edsl/to_display.ml
+++ b/src/pipeline_edsl/to_display.ml
@@ -24,20 +24,18 @@ let apply f v =
 
 let observe f = f () ~var_count:0
 
-module List_repr = struct
-  let make l =
-    fun ~var_count ->
-      SP.nest (OCaml.list (fun a -> a ~var_count) l)
+let list l =
+  fun ~var_count ->
+    SP.nest (OCaml.list (fun a -> a ~var_count) l)
 
-  let map l ~f =
-    let open SP in
-    fun ~var_count ->
-      entity (
-        string "List.map"
-        ^^ nest (string "~f:" ^^ f ~var_count)
-        ^^ l ~var_count
-      )
-end
+let list_map l ~f =
+  let open SP in
+  fun ~var_count ->
+    entity (
+      string "List.map"
+      ^^ nest (string "~f:" ^^ f ~var_count)
+      ^^ l ~var_count
+    )
 
 include To_json.Make_serializer (struct
     type t = SP.t

--- a/src/pipeline_edsl/to_dot.ml
+++ b/src/pipeline_edsl/to_dot.ml
@@ -110,19 +110,17 @@ let apply f v =
 
 let observe f = f () ~var_count:0 |> Tree.to_dot
 
-module List_repr = struct
-  let make l =
+  let list l =
     fun ~var_count ->
       Tree.node "List.make"
         (List.mapi ~f:(fun i a -> Tree.arrow (sprintf "L%d" i) (a ~var_count)) l)
 
-  let map l ~f =
-    fun ~var_count ->
-      Tree.node "List.map" [
-        Tree.arrow "list" (l ~var_count);
-        Tree.arrow "function" (f ~var_count);
-      ]
-end
+let list_map l ~f =
+  fun ~var_count ->
+    Tree.node "List.map" [
+      Tree.arrow "list" (l ~var_count);
+      Tree.arrow "function" (f ~var_count);
+    ]
 
 include To_json.Make_serializer (struct
     type t = Tree.t

--- a/src/pipeline_edsl/to_dot.ml
+++ b/src/pipeline_edsl/to_dot.ml
@@ -1,0 +1,134 @@
+
+open Nonstd
+
+module Tree = struct
+  type box = { id: string; name : string; attributes: (string * string) list}
+  (* type action = string *)
+  type arrow = {
+    label: string;
+    points_to: t
+  } and t = [
+    | `Leaf of box
+    | `Node of box * arrow list
+  ]
+  let node_count = ref 0
+  let make_id () = incr node_count; sprintf "node%03d" !node_count
+  let arrow label points_to = {label; points_to}
+  let node name l : t = `Node ({id = make_id (); name; attributes = []}, l)
+  let leaf ?(a = []) name : t = `Leaf {id = make_id (); name; attributes = a}
+
+  let to_dot t =
+    let open SmartPrint in
+    let semicolon = string ";" in
+    let sentence sp = sp ^-^ semicolon ^-^ newline in
+    let dot_attributes l =
+      brakets (
+        List.map l ~f:(fun (k, v) ->
+            string k ^^ string "=" ^^ v) |> separate (semicolon)
+      ) in
+    let in_quotes s = ksprintf string "\"%s\"" s in
+    let label_attribute lab = ("label", in_quotes lab) in
+    let font_name `Mono =
+      ("fontname", in_quotes "monospace") in
+    let font_size =
+      function
+      | `Small -> ("fontsize", in_quotes "12")
+      | `Default -> ("fontsize", in_quotes "16")
+    in
+    let dot_arrow src dest = string src ^^ string "->" ^^ string dest in
+    let id_of =
+      function
+      | `Leaf {id; _} -> id
+      | `Node ({id; _}, _) -> id in
+    let rec go =
+      function
+      | `Leaf {id; name; attributes} ->
+        let label =
+          match attributes with
+          | [] -> name
+          | _ ->
+            sprintf "{<f0>%s |<f1> %s\\l }" name
+              (List.map attributes ~f:(fun (k,v) -> sprintf "%s: %s" k v)
+               |> String.concat "\\l")
+        in
+        sentence (
+          string id ^^ dot_attributes [
+            label_attribute label;
+            font_name `Mono;
+            "shape", in_quotes "Mrecord";
+          ]
+        )
+      | `Node ({id; name; attributes}, trees) ->
+        sentence (
+          string id ^^ dot_attributes [
+            label_attribute name;
+            font_name `Mono;
+          ]
+        )
+        ^-^ separate empty (
+          List.map trees ~f:(fun {label; points_to} ->
+              sentence (
+                dot_arrow (id_of points_to) id ^^ dot_attributes [
+                  label_attribute label;
+                  font_size `Small;
+                ]
+              )
+              ^-^ go points_to)
+        )
+    in
+    let dot =
+      string "digraph target_graph" ^^ braces (nest (
+          sentence (
+            string "graph" ^^ dot_attributes [
+              "rankdir", in_quotes "LR";
+              font_size `Default;
+            ]
+          )
+          ^-^ go t
+        ))
+    in
+    SmartPrint.to_string 80 2 dot
+end
+
+
+type 'a repr = var_count: int -> Tree.t
+
+type 'a observation = string
+
+let lambda f =
+  fun ~var_count ->
+    let var_name = sprintf "Var%d" var_count in
+    let var_repr = fun ~var_count -> Tree.leaf var_name in
+    let applied = f var_repr ~var_count:(var_count + 1) in
+    Tree.node "Lambda" [Tree.arrow var_name applied]
+
+let apply f v =
+  fun ~var_count ->
+    let func = f ~var_count in
+    let arg = v ~var_count in
+    Tree.node "Apply" [Tree.arrow "f" func; Tree.arrow "arg" arg]
+
+let observe f = f () ~var_count:0 |> Tree.to_dot
+
+module List_repr = struct
+  let make l =
+    fun ~var_count ->
+      Tree.node "List.make"
+        (List.mapi ~f:(fun i a -> Tree.arrow (sprintf "L%d" i) (a ~var_count)) l)
+
+  let map l ~f =
+    fun ~var_count ->
+      Tree.node "List.map" [
+        Tree.arrow "list" (l ~var_count);
+        Tree.arrow "function" (f ~var_count);
+      ]
+end
+
+include To_json.Make_serializer (struct
+    type t = Tree.t
+    let input_value name a ~var_count =
+      Tree.leaf name ~a
+    let function_call name params =
+      Tree.node name (List.map ~f:(fun (k,v) -> Tree.arrow k v) params)
+    let string s = Tree.leaf s
+  end)

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -29,18 +29,16 @@ let apply f v =
 let observe f = f () ~var_count:0
 
 
-module List_repr = struct
-  let make l =
-    fun ~var_count ->
-      `List (List.map ~f:(fun a -> a ~var_count) l)
+let list l =
+  fun ~var_count ->
+    `List (List.map ~f:(fun a -> a ~var_count) l)
 
-  let map l ~f =
-    fun ~var_count ->
-      `Assoc [
-        "list-map", f ~var_count;
-        "argument", l ~var_count;
-      ]
-end
+let list_map l ~f =
+  fun ~var_count ->
+    `Assoc [
+      "list-map", f ~var_count;
+      "argument", l ~var_count;
+    ]
 
 module Make_serializer (How : sig
     type t

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -1,0 +1,126 @@
+open Nonstd
+module Tools = Biokepi_bfx_tools
+
+type json = Yojson.Basic.json
+
+type 'a repr = var_count : int -> json
+
+type 'a observation = json
+
+let lambda f =
+  fun ~var_count ->
+    let var_name = sprintf "var%d" var_count in
+    let var_repr = fun ~var_count -> `String var_name in
+    let applied = f var_repr ~var_count:(var_count + 1) in
+    `Assoc [
+      "lambda", `String var_name;
+      "body", applied;
+    ]
+
+let apply f v =
+  fun ~var_count ->
+    let func = f ~var_count in
+    let arg = v ~var_count in
+    `Assoc [
+      "function", func;
+      "argument", arg;
+    ]
+
+let observe f = f () ~var_count:0
+
+
+module List_repr = struct
+  let make l =
+    fun ~var_count ->
+      `List (List.map ~f:(fun a -> a ~var_count) l)
+
+  let map l ~f =
+    fun ~var_count ->
+      `Assoc [
+        "list-map", f ~var_count;
+        "argument", l ~var_count;
+      ]
+end
+
+module Make_serializer (How : sig
+    type t
+    val input_value :
+      string -> (string * string) list -> var_count:int -> t
+    val function_call :
+      string -> (string * t) list -> t
+    val string : string -> t
+  end) = struct
+  open How
+
+  let fastq
+      ~sample_name ?fragment_id ~r1 ?r2 () =
+    input_value "fastq" [
+      "sample_name", sample_name;
+      "fragment_id", Option.value ~default:"NONE" fragment_id;
+      "R1", r1;
+      "R2", Option.value ~default:"NONE" r2;
+    ]
+
+  let fastq_gz
+      ~sample_name ?fragment_id ~r1 ?r2 () =
+    input_value "fastq.gz" [
+      "sample_name", sample_name;
+      "fragment_id", Option.value ~default:"NONE" fragment_id;
+      "R1", r1;
+      "R2", Option.value ~default:"NONE" r2;
+    ]
+
+  let bam ~path ?sorting ~reference_build () =
+    input_value "bam" [
+      "path", path;
+      "sorting",
+      Option.value_map ~default:"NONE" sorting
+        ~f:(function `Coordinate -> "Coordinate" | `Read_name -> "Read-name");
+      "reference_build", reference_build;
+    ]
+
+
+  let bwa_aln
+      ?(configuration = Tools.Bwa.Configuration.Aln.default)
+      ~reference_build fq ~var_count =
+    let fq_compiled = fq ~var_count in
+    function_call "bwa-aln" [
+      "configuration",
+      Tools.Bwa.Configuration.Aln.name configuration |> string;
+      "reference_build", string reference_build;
+      "input", fq_compiled;
+    ]
+
+  let gunzip gz ~var_count =
+    function_call "gunzip" ["input", gz ~var_count]
+
+  let gunzip_concat gzl ~var_count =
+    function_call "gunzip-concat" ["input-list", gzl ~var_count]
+
+  let concat l ~var_count =
+    function_call "concat" ["input-list", l ~var_count]
+
+  let merge_bams bl ~var_count =
+    function_call "merge-bams" ["input-list", bl ~var_count]
+
+  let mutect ~configuration ~normal ~tumor ~var_count =
+    function_call "mutect" [
+      "configuration", string configuration.Tools.Mutect.Configuration.name;
+      "normal", normal ~var_count;
+      "tumor", tumor ~var_count;
+    ]
+end
+
+include Make_serializer (struct
+    type t = json
+    let input_value name kv =
+      fun ~var_count ->
+        `Assoc (
+          ("input-value", `String name)
+          :: List.map kv ~f:(fun (k, v) -> k, `String v)
+        )
+    let function_call name params =
+      `Assoc ( ("function-call", `String name) :: params)
+    let string s = `String s
+  end)
+

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -66,14 +66,12 @@ module Make (Config : Compiler_configuration)
     | Lambda f -> f x
     | _ -> assert false
 
-  module List_repr = struct
-    let make : 'a repr list -> 'a list repr = fun l -> List l
-    let map : 'a list repr -> f:('a -> 'b) repr -> 'b list repr = fun l ~f ->
-      match l with
-      | List l ->
-        List (List.map ~f:(fun v -> apply f v) l)
-      | _ -> assert false
-  end
+  let list : 'a repr list -> 'a list repr = fun l -> List l
+  let list_map : 'a list repr -> f:('a -> 'b) repr -> 'b list repr = fun l ~f ->
+    match l with
+    | List l ->
+      List (List.map ~f:(fun v -> apply f v) l)
+    | _ -> assert false
 
   let host = Machine.as_host Config.machine
   let run_with = Config.machine

--- a/src/pipeline_edsl/transform_applications.ml
+++ b/src/pipeline_edsl/transform_applications.ml
@@ -1,0 +1,53 @@
+
+(** 
+
+   We use here the {!Optimization_framework} module to apply a big more than
+   {{:https://en.wikipedia.org/wiki/Lambda_calculus}Β-reduction}.  We also try
+   to apply the [List_repr.map], and build [List_repr.make] values.
+
+*)
+
+open Nonstd
+
+module Apply_optimization_framework
+    (Input : Semantics.Bioinformatics_base)
+= struct
+  module Transformation_types = struct
+    type 'a from = 'a Input.repr
+    type 'a term = 
+      | Unknown : 'a from -> 'a term
+      | Apply : ('a -> 'b) term * 'a term -> 'b term
+      | Lambda : ('a term -> 'b term) -> ('a -> 'b) term
+      | List_make: ('a term) list -> 'a list term
+      | List_map: ('a list term * ('a -> 'b) term) -> 'b list term
+    let fwd x = Unknown x
+    let rec bwd : type a. a term -> a from =
+      function
+      | Apply (Lambda f, v) -> bwd (f v)
+      | Apply (other, v) -> Input.apply (bwd other) (bwd v)
+      | List_map (List_make l, Lambda f) -> 
+        Input.list (List.map ~f:(fun x -> bwd (f x)) l)
+      | List_map (x, f) ->
+        Input.list_map ~f:(bwd f) (bwd x)
+      | Lambda f ->
+        Input.lambda (fun x -> (bwd (f (fwd x))))
+      | List_make l -> Input.list (List.map ~f:bwd l)
+      | Unknown x -> x
+  end
+  open Transformation_types
+  module Transformation =
+    Optimization_framework.Define_transformation(Transformation_types)
+  open Transformation
+  module Language_delta = struct
+    let apply f x = Apply (f, x)
+    let lambda f = Lambda f
+    let list l = List_make l
+    let list_map l ~f = List_map (l, f)
+  end
+end
+module Make (Input : Semantics.Bioinformatics_base) = struct
+  module The_pass = Apply_optimization_framework(Input)
+  include Optimization_framework.Generic_optimizer(The_pass.Transformation)(Input)
+  include The_pass.Language_delta
+end
+

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -84,9 +84,12 @@ module KEDSL = struct
       val r2_file_opt = Option.map r2_opt ~f:(single_file ?host)
       method r1 =
         workflow_node r1_file
+          ~name:(sprintf "File: %s" (Filename.basename r1_file#path))
       method r2 = 
         Option.map r2_file_opt ~f:(fun r2_file ->
-            workflow_node r2_file)
+            workflow_node r2_file
+              ~name:(sprintf "File: %s" (Filename.basename r2_file#path))
+          )
       method paths = (r1, r2_opt)
       method is_done =
         Some (match r2_file_opt with

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -92,7 +92,7 @@ let () =
   cmdf "dot -v -Tpng  %s -o %s" pipeline_1_dot pipeline_1_png;
 
   let module Dotize_beta_reduced_pipeline_1 =
-    Pipeline_1(Biokepi.EDSL.Transform.Beta_reduce(Biokepi.EDSL.Compile.To_dot))
+    Pipeline_1(Biokepi.EDSL.Transform.Apply_functions(Biokepi.EDSL.Compile.To_dot))
   in
   let pipeline_1_beta_dot = test_dir // "pipeline-1-beta.dot" in
   write_file pipeline_1_dot

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -91,6 +91,15 @@ let () =
   let pipeline_1_png = test_dir // "pipeline-1.png" in
   cmdf "dot -v -Tpng  %s -o %s" pipeline_1_dot pipeline_1_png;
 
+  let module Dotize_beta_reduced_pipeline_1 =
+    Pipeline_1(Biokepi.EDSL.Transform.Beta_reduce(Biokepi.EDSL.Compile.To_dot))
+  in
+  let pipeline_1_beta_dot = test_dir // "pipeline-1-beta.dot" in
+  write_file pipeline_1_dot
+    ~content:(Dotize_beta_reduced_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1);
+  let pipeline_1_beta_png = test_dir // "pipeline-1-beta.png" in
+  cmdf "dot -v -Tpng  %s -o %s" pipeline_1_beta_dot pipeline_1_beta_png;
+
   let module Workflow_compiler =
     Biokepi.EDSL.Compile.To_workflow.Make(struct
       let processors = 42
@@ -115,12 +124,14 @@ let () =
          \  Dot: %s\n\
          \  SVG: %s\n\
          \  PNG: %s\n\
+         \  Beta-reduced PNG: %s\n\
          \  ketrew-display: %s\n%!"
     pipeline_1_display
     pipeline_1_json
     pipeline_1_dot
     pipeline_1_svg
     pipeline_1_png
+    pipeline_1_beta_png
     pipeline_1_workflow_display
 
 

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -82,6 +82,15 @@ let () =
     ~content:(Jsonize_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1
               |> Yojson.Basic.pretty_to_string ~std:true);
 
+  let module Dotize_pipeline_1 = Pipeline_1(Biokepi.EDSL.Compile.To_dot) in
+  let pipeline_1_dot = test_dir // "pipeline-1.dot" in
+  write_file pipeline_1_dot
+    ~content:(Dotize_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1);
+  let pipeline_1_svg = test_dir // "pipeline-1.svg" in
+  cmdf "dot -x -Grotate=180 -v -Tsvg  %s -o %s" pipeline_1_dot pipeline_1_svg;
+  let pipeline_1_png = test_dir // "pipeline-1.png" in
+  cmdf "dot -v -Tpng  %s -o %s" pipeline_1_dot pipeline_1_png;
+
   let module Workflow_compiler =
     Biokepi.EDSL.Compile.To_workflow.Make(struct
       let processors = 42
@@ -103,7 +112,15 @@ let () =
   printf "Pipeline_1:\n\
          \  display: %s\n\
          \  JSON: %s\n\
+         \  Dot: %s\n\
+         \  SVG: %s\n\
+         \  PNG: %s\n\
          \  ketrew-display: %s\n%!"
-    pipeline_1_display pipeline_1_json pipeline_1_workflow_display
+    pipeline_1_display
+    pipeline_1_json
+    pipeline_1_dot
+    pipeline_1_svg
+    pipeline_1_png
+    pipeline_1_workflow_display
 
 

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -14,14 +14,14 @@ module Pipeline_1 (Bfx : Biokepi.EDSL.Semantics) = struct
       else
         Bfx.(fastq ~sample_name:dataset ~r1 ~r2 ())
     end
-    |> Bfx.List_repr.make
+    |> Bfx.list
 
 
   let mutect_on_fastqs ~reference_build ~normal ~tumor =
     let aligner =
       Bfx.lambda (fun fq -> Bfx.bwa_aln ~reference_build fq) in
     let align_list list_of_fastqs =
-      Bfx.List_repr.map list_of_fastqs ~f:aligner |> Bfx.merge_bams
+      Bfx.list_map list_of_fastqs ~f:aligner |> Bfx.merge_bams
     in
     Bfx.mutect
       ~configuration:Biokepi.Tools.Mutect.Configuration.default

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -38,17 +38,17 @@ module Pipeline_1 (Bfx : Biokepi.EDSL.Semantics) = struct
 
 end
 
-let normal_1 = 
+let normal_1 =
   ("normal-1", [
-      `Pair ("/input/normal-1-001-r1.fastq", "/input/normal-1-001-r2.fastq"); 
-      `Pair ("/input/normal-1-002-r1.fastq", "/input/normal-1-002-r2.fastq"); 
-      `Pair ("/input/normal-1-003-r1.fqz",   "/input/normal-1-003-r2.fqz"); 
+      `Pair ("/input/normal-1-001-r1.fastq", "/input/normal-1-001-r2.fastq");
+      `Pair ("/input/normal-1-002-r1.fastq", "/input/normal-1-002-r2.fastq");
+      `Pair ("/input/normal-1-003-r1.fqz",   "/input/normal-1-003-r2.fqz");
     ])
 
-let tumor_1 = 
+let tumor_1 =
   ("tumor-1", [
-      `Pair ("/input/tumor-1-001-r1.fastq.gz", "/input/tumor-1-001-r2.fastq.gz"); 
-      `Pair ("/input/tumor-1-002-r1.fastq.gz", "/input/tumor-1-002-r2.fastq.gz"); 
+      `Pair ("/input/tumor-1-001-r1.fastq.gz", "/input/tumor-1-001-r2.fastq.gz");
+      `Pair ("/input/tumor-1-002-r1.fastq.gz", "/input/tumor-1-002-r2.fastq.gz");
     ])
 
 let write_file file ~content =
@@ -60,7 +60,7 @@ let write_file file ~content =
     close_out out_file
 
 let cmdf fmt =
-  ksprintf (fun s -> 
+  ksprintf (fun s ->
       match Sys.command s with
       | 0 -> ()
       | other -> ksprintf failwith "non-zero-exit: %s → %d" s other) fmt
@@ -75,6 +75,12 @@ let () =
   write_file pipeline_1_display
     ~content:(Display_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1
               |> SmartPrint.to_string 80 2);
+
+  let module Jsonize_pipeline_1 = Pipeline_1(Biokepi.EDSL.Compile.To_json) in
+  let pipeline_1_json = test_dir // "pipeline-1.json" in
+  write_file pipeline_1_json
+    ~content:(Jsonize_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1
+              |> Yojson.Basic.pretty_to_string ~std:true);
 
   let module Workflow_compiler =
     Biokepi.EDSL.Compile.To_workflow.Make(struct
@@ -96,7 +102,8 @@ let () =
     ~content:(workflow_1 |> Ketrew.EDSL.workflow_to_string);
   printf "Pipeline_1:\n\
          \  display: %s\n\
+         \  JSON: %s\n\
          \  ketrew-display: %s\n%!"
-    pipeline_1_display pipeline_1_workflow_display
+    pipeline_1_display pipeline_1_json pipeline_1_workflow_display
 
 


### PR DESCRIPTION

New things:

- Compilers `To_json` and `To_dot`
- Generic `Optimization_framework` (from QueL)
- One optimization pass that has mostly “display-value”

Not sure if `Biokepi.EDS.Transform.Beta_reduce` can be called like that. This is what the test outputs:

Pipeline:

![pipeline-1 dot](https://cloud.githubusercontent.com/assets/617111/14540494/4c3d6646-0253-11e6-9372-538fab53acbc.png)

Pipeline with `Transform_applications` applied:

![pipeline-1-beta](https://cloud.githubusercontent.com/assets/617111/14540521/7084173e-0253-11e6-96c9-b0729f3bb8fe.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/236)
<!-- Reviewable:end -->
