### PR TITLE
Hack better build for the documentation

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -109,7 +109,7 @@ build-all: lib-biokepi_run_environment \
 
 DOC_PACKAGES[] = $(LIB_PACKAGES)
 doc:
-    sh ./tools/build-doc.sh $(concat \,, $(LIB_PACKAGES))
+    ./tools/build-doc.sh $(concat \,, $(LIB_PACKAGES))
 
 
 DIRS[] = src/run_environment/ src/environment_setup/ src/bfx_tools/ src/pipeline_edsl/ src/lib

--- a/src/pipeline_edsl/pipeline.ml
+++ b/src/pipeline_edsl/pipeline.ml
@@ -754,9 +754,13 @@ module Compiler = struct
     in
     compiler.wrap_bam_node pipeline bam_node
 
-  let rec compile_bam_pair ~compiler =
+  let rec compile_bam_pair ~compiler (pipeline : bam_pair pipeline) :
+      [ `Normal of KEDSL.bam_file KEDSL.workflow_node ] *
+      [ `Tumor of KEDSL.bam_file KEDSL.workflow_node ] *
+      [ `Pipeline of bam_pair pipeline ]
+    =
     let {processors ; reference_build; work_dir; machine; _} = compiler in
-    begin function
+    begin match pipeline with
     | Bam_pair (
         (Gatk_bqsr (n_bqsr_config, Gatk_indel_realigner (n_gir_conf, n_bam)))
         ,


### PR DESCRIPTION
The script `./tools/build-doc.sh` now generates “big” modules that are what the
“pack” option does.

The signature of one function in `./src/pipeline_edsl/pipeline.ml` had to be
forced so that `ocamlc -i` can generate valid code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/238)
<!-- Reviewable:end -->
