### PR TITLE
TTFI, the third

### DIFF
--- a/src/bfx_tools/gatk.ml
+++ b/src/bfx_tools/gatk.ml
@@ -32,6 +32,8 @@ module Configuration = struct
       parameters: (string * string) list;
     }
 
+    let name t = t.name
+
     let to_json t: Yojson.Basic.json =
       let {name;
            filter_reads_with_n_cigar;
@@ -131,6 +133,8 @@ module Configuration = struct
       in
       (`Arguments (List.concat args @ additional_arguments),
        `Edges (List.concat edges))
+
+    let name t = t.name
   end
 
 

--- a/src/bfx_tools/gatk.ml
+++ b/src/bfx_tools/gatk.ml
@@ -6,7 +6,7 @@ module Remove = Workflow_utilities.Remove
 
 module Configuration = struct
 
-  module Gatk_config = struct
+  module Gatk_config () = struct
     type t = {
       (** The name of the configuration, specific to Biokepi. *)
       name: string;
@@ -70,19 +70,19 @@ module Configuration = struct
   end
 
   module Indel_realigner = struct
-    include Gatk_config
+    include Gatk_config ()
   end
 
   module Realigner_target_creator = struct
-    include Gatk_config
+    include Gatk_config ()
   end
 
   module Bqsr = struct
-    include Gatk_config
+    include Gatk_config ()
   end
 
   module Print_reads = struct
-    include Gatk_config
+    include Gatk_config ()
   end
 
   type indel_realigner = (Indel_realigner.t * Realigner_target_creator.t)
@@ -175,7 +175,7 @@ let indel_realigner_output_filename_tag
     "_indelreal-";
     ir_config.Configuration.Indel_realigner.name;
     "-";
-    target_config.Configuration.Indel_realigner.name;
+    target_config.Configuration.Realigner_target_creator.name;
     "-";
     sprintf "-%dx" bam_number;
     (if bam_number = 1 then "" else "-" ^ digest_of_input ());

--- a/src/bfx_tools/hisat.ml
+++ b/src/bfx_tools/hisat.ml
@@ -19,6 +19,7 @@ module Configuration = struct
     ]
   let default_v1 = {name = "default_v1"; version = `V_0_1_6_beta}
   let default_v2 = {name = "default_v2"; version = `V_2_0_2_beta}
+  let name t = t.name
 end
 
 let index

--- a/src/bfx_tools/muse.ml
+++ b/src/bfx_tools/muse.ml
@@ -12,6 +12,8 @@ module Configuration = struct
     input_type: [ `WGS | `WES ];
   }
 
+  let name t = t.name
+
   let input_type_to_string input_type =
     match input_type with
     | `WGS -> "WGS"

--- a/src/bfx_tools/mutect.ml
+++ b/src/bfx_tools/mutect.ml
@@ -32,6 +32,7 @@ module Configuration = struct
      with_cosmic = false; with_dbsnp = true;
      parameters = []}
 
+  let name t = t.name
 
 end
 

--- a/src/bfx_tools/picard.ml
+++ b/src/bfx_tools/picard.ml
@@ -72,6 +72,7 @@ let sort_vcf ~(run_with:Machine.t) ?(sequence_dict) input_vcf =
 
 module Mark_duplicates_settings = struct
   type t = {
+    name: string;
     tmpdir: string;
     max_sequences_for_disk_read_ends_map: int;
     max_file_handles_for_read_ends_map: int;
@@ -79,6 +80,7 @@ module Mark_duplicates_settings = struct
     mem_param: string option;
   }
   let factory = {
+    name = "factory";
     tmpdir = "/tmp";
     max_sequences_for_disk_read_ends_map = 50000;
     max_file_handles_for_read_ends_map = 8000;
@@ -88,6 +90,7 @@ module Mark_duplicates_settings = struct
 
   let default = {
     factory with
+    name = "default";
     max_file_handles_for_read_ends_map = 20_000;
   }
 

--- a/src/bfx_tools/strelka.ml
+++ b/src/bfx_tools/strelka.ml
@@ -20,6 +20,7 @@ module Configuration = struct
     name: string;
     parameters: (string * string) list
   }
+  let name t = t.name
   let to_json {name; parameters}: Yojson.Basic.json =
     `Assoc [
       "name", `String name;

--- a/src/bfx_tools/virmid.ml
+++ b/src/bfx_tools/virmid.ml
@@ -33,6 +33,7 @@ module Configuration = struct
        "-C2", "100";
      ]}
 
+  let name t = t.name
 end
 
 let run

--- a/src/environment_setup/tool_providers.ml
+++ b/src/environment_setup/tool_providers.ml
@@ -489,27 +489,30 @@ let default_toolkit
     ?(mutect_jar_location = default_jar_location "Mutect")
     ?(gatk_jar_location = default_jar_location "GATK")
     () =
-  Machine.Tool.Kit.create [
-    bwa_tool ~host ~meta_playground;
-    samtools ~host ~meta_playground;
-    bedtools ~host ~meta_playground;
-    vcftools ~host ~meta_playground;
-    strelka_tool ~host ~meta_playground;
-    mutect_tool
-      ~host ~meta_playground (mutect_jar_location ());
-    gatk_tool
-      ~host ~meta_playground (gatk_jar_location ());
-    picard_tool ~host ~meta_playground;
-    somaticsniper_tool ~host ~meta_playground;
-    varscan_tool ~host ~meta_playground;
-    muse_tool ~host ~meta_playground;
-    virmid_tool ~host ~meta_playground;
-    star_tool ~host ~meta_playground;
-    stringtie_tool ~host ~meta_playground;
-    cufflinks_tools ~host ~meta_playground;
-    hisat_tool ~host ~meta_playground ~version:`V_0_1_6_beta;
-    hisat_tool ~host ~meta_playground ~version:`V_2_0_2_beta;
-    mosaik_tool ~host ~meta_playground;
-    kallisto_tool ~host ~meta_playground;
+  Machine.Tool.Kit.concat [
+    Machine.Tool.Kit.create [
+      bwa_tool ~host ~meta_playground;
+      samtools ~host ~meta_playground;
+      bedtools ~host ~meta_playground;
+      vcftools ~host ~meta_playground;
+      strelka_tool ~host ~meta_playground;
+      mutect_tool
+        ~host ~meta_playground (mutect_jar_location ());
+      gatk_tool
+        ~host ~meta_playground (gatk_jar_location ());
+      picard_tool ~host ~meta_playground;
+      somaticsniper_tool ~host ~meta_playground;
+      varscan_tool ~host ~meta_playground;
+      muse_tool ~host ~meta_playground;
+      virmid_tool ~host ~meta_playground;
+      star_tool ~host ~meta_playground;
+      stringtie_tool ~host ~meta_playground;
+      cufflinks_tools ~host ~meta_playground;
+      hisat_tool ~host ~meta_playground ~version:`V_0_1_6_beta;
+      hisat_tool ~host ~meta_playground ~version:`V_2_0_2_beta;
+      mosaik_tool ~host ~meta_playground;
+      kallisto_tool ~host ~meta_playground;
+    ];
+    Biopam.default ~host ~install_path:(meta_playground // "biopam-kit") ();
   ]
 

--- a/src/lib/biokepi.ml
+++ b/src/lib/biokepi.ml
@@ -140,7 +140,7 @@ module EDSL = struct
         graph descriptions.  *)
     module To_dot : Semantics.Bioinformatics_base
       with 
-       type 'a observation = string =
+       type 'a observation = SmartPrint.t =
       Biokepi_pipeline_edsl.To_dot
   end
 

--- a/src/pipeline_edsl/common_pipelines.ml
+++ b/src/pipeline_edsl/common_pipelines.ml
@@ -61,7 +61,12 @@ module Somatic = struct
           [
             mutect bam_pair;
             somaticsniper bam_pair;
-            somaticsniper ~prior_probability:0.001 ~theta:0.95 bam_pair;
+            somaticsniper
+              ~configuration:Somaticsniper.Configuration.{
+                  name = "example0001-095";
+                  prior_probability = 0.001;
+                  theta = 0.95;
+                } bam_pair;
             varscan_somatic bam_pair;
             strelka ~configuration:Strelka.Configuration.exome_default bam_pair;
           ])

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -71,6 +71,10 @@ module Generic_optimizer
 
   let bwa_aln ?configuration ~reference_build fq =
     fwd (Input.bwa_aln ?configuration ~reference_build (bwd fq))
+
+  let bwa_mem ?configuration ~reference_build fq =
+    fwd (Input.bwa_mem ?configuration ~reference_build (bwd fq))
+
   let gunzip gz =
     fwd (Input.gunzip (bwd gz))
 

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -60,6 +60,10 @@ module Generic_optimizer
   let list_map l ~f =
     fwd (Input.list_map (bwd l) (bwd f))
 
+  let pair a b = fwd (Input.pair (bwd a) (bwd b))
+  let pair_first x = fwd (Input.pair_first (bwd x))
+  let pair_second x = fwd (Input.pair_second (bwd x))
+
   let fastq ~sample_name ?fragment_id ~r1 ?r2 () =
     fwd (Input.fastq ~sample_name ?fragment_id ~r1 ?r2 ())
 
@@ -75,6 +79,40 @@ module Generic_optimizer
   let bwa_mem ?configuration ~reference_build fq =
     fwd (Input.bwa_mem ?configuration ~reference_build (bwd fq))
 
+  let star ~configuration ~reference_build fq =
+    fwd (Input.star ~configuration ~reference_build (bwd fq))
+
+  let hisat ~configuration ~reference_build fq =
+    fwd (Input.hisat ~configuration ~reference_build (bwd fq))
+
+  let mosaik ~reference_build fq =
+    fwd (Input.mosaik ~reference_build (bwd fq))
+
+  let stringtie ~configuration fq =
+    fwd (Input.stringtie ~configuration (bwd fq))
+
+  let gatk_indel_realigner ~configuration bam =
+    fwd (Input.gatk_indel_realigner ~configuration (bwd bam))
+
+  let gatk_indel_realigner_joint ~configuration pair =
+    fwd (Input.gatk_indel_realigner_joint ~configuration (bwd pair))
+
+  let picard_mark_duplicates ~configuration bam =
+    fwd (Input.picard_mark_duplicates ~configuration (bwd bam))
+
+  let gatk_bqsr ~configuration bam =
+    fwd (Input.gatk_bqsr ~configuration (bwd bam))
+
+  let seq2hla fq =
+    fwd (Input.seq2hla (bwd fq))
+
+  let optitype how fq =
+    fwd (Input.optitype how (bwd fq))
+
+  let gatk_haplotype_caller bam =
+    fwd (Input.gatk_haplotype_caller (bwd bam))
+
+
   let gunzip gz =
     fwd (Input.gunzip (bwd gz))
 
@@ -87,7 +125,23 @@ module Generic_optimizer
   let merge_bams bl =
     fwd (Input.merge_bams (bwd bl))
 
+  let bam_to_fastq ~sample_name ?fragment_id se_or_pe bam =
+    fwd (Input.bam_to_fastq ~sample_name ?fragment_id se_or_pe (bwd bam))
+
   let mutect ~configuration ~normal ~tumor =
     fwd (Input.mutect ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+  let mutect2 ~configuration ~normal ~tumor =
+    fwd (Input.mutect2 ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+  let somaticsniper ~configuration ~normal ~tumor =
+    fwd (Input.somaticsniper ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+  let strelka ~configuration ~normal ~tumor =
+    fwd (Input.strelka ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+  let varscan_somatic ?adjust_mapq ~normal ~tumor =
+    fwd (Input.varscan_somatic
+           ?adjust_mapq ~normal:(bwd normal) ~tumor:(bwd tumor))
+  let muse ~configuration ~normal ~tumor =
+    fwd (Input.muse ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+  let virmid ~configuration ~normal ~tumor =
+    fwd (Input.virmid ~configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
 
 end

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -60,6 +60,8 @@ module Generic_optimizer
   let list_map l ~f =
     fwd (Input.list_map (bwd l) (bwd f))
 
+  let to_unit x = fwd (Input.to_unit (bwd x))
+
   let pair a b = fwd (Input.pair (bwd a) (bwd b))
   let pair_first x = fwd (Input.pair_first (bwd x))
   let pair_second x = fwd (Input.pair_second (bwd x))

--- a/src/pipeline_edsl/pipeline.ml
+++ b/src/pipeline_edsl/pipeline.ml
@@ -390,7 +390,7 @@ let rec to_file_prefix:
       sprintf "%s-bqsr-%s-%s"
         (to_file_prefix ?read bam)
         bqsr_cfg.Bqsr.name
-        bqsr_cfg.Print_reads.name
+        print_reads_cfg.Print_reads.name
     | Picard_mark_duplicates (_, bam) ->
       (* The settings, for now, do not impact the result *)
       sprintf "%s-dedup" (to_file_prefix ?read bam)

--- a/src/pipeline_edsl/pipeline.ml
+++ b/src/pipeline_edsl/pipeline.ml
@@ -234,27 +234,18 @@ module Construct = struct
       bam_pair
 
   let somaticsniper
-      ?(prior_probability=Somaticsniper.default_prior_probability)
-      ?(theta=Somaticsniper.default_theta)
+      ?(configuration = Somaticsniper.Configuration.default)
       bam_pair =
-    let configuration_name =
-      sprintf "S%F-T%F" prior_probability theta in
-    let configuration_json =
-      `Assoc [
-        "Name", `String configuration_name;
-        "Prior-probability", `Float prior_probability;
-        "Theta", `Float theta;
-      ] in
     let make_target
         ~run_with ~input ~result_prefix ~processors ?more_edges () =
-      match input with | Variant_caller.Somatic {normal; tumor} ->
-      Somaticsniper.run
-        ~run_with ~minus_s:prior_probability ~minus_T:theta
-        ~normal ~tumor ~result_prefix () in
+      match input with
+      | Variant_caller.Somatic {normal; tumor} ->
+        Somaticsniper.run
+          ~configuration ~run_with ~normal ~tumor ~result_prefix () in
     somatic_variant_caller
       {Variant_caller.name = "Somaticsniper";
-       configuration_json;
-       configuration_name;
+       configuration_json = Somaticsniper.Configuration.to_json configuration;
+       configuration_name = Somaticsniper.Configuration.name configuration;
        make_target;}
       bam_pair
 

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -27,6 +27,9 @@ module type Bioinformatics_base = sig
   val pair_first: ('a * 'b) repr -> 'a repr
   val pair_second: ('a * 'b) repr -> 'b repr
 
+  (** This is used to opacify the type of the expression. *)
+  val to_unit: 'a repr -> unit repr
+
   val fastq :
     sample_name : string ->
     ?fragment_id : string ->

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -46,6 +46,12 @@ module type Bioinformatics_base = sig
     [ `Fastq ] repr ->
     [ `Bam ] repr
 
+  val bwa_mem:
+    ?configuration: Biokepi_bfx_tools.Bwa.Configuration.Mem.t ->
+    reference_build: Biokepi_run_environment.Reference_genome.name ->
+    [ `Fastq ] repr ->
+    [ `Bam ] repr
+
   val gunzip: [ `Gz of 'a] repr -> 'a repr
 
   val gunzip_concat: ([ `Gz of 'a] list) repr -> 'a repr

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -21,7 +21,13 @@ module type Bioinformatics_base = sig
 
   include Lambda_with_list_operations
 
-  val fastq : 
+  open Biokepi_bfx_tools
+
+  val pair: 'a repr -> 'b repr -> ('a * 'b) repr
+  val pair_first: ('a * 'b) repr -> 'a repr
+  val pair_second: ('a * 'b) repr -> 'b repr
+
+  val fastq :
     sample_name : string ->
     ?fragment_id : string ->
     r1: string ->
@@ -40,6 +46,23 @@ module type Bioinformatics_base = sig
     reference_build: string ->
     unit -> [ `Bam ] repr
 
+
+
+  val gunzip: [ `Gz of 'a] repr -> 'a repr
+
+  val gunzip_concat: ([ `Gz of 'a] list) repr -> 'a repr
+
+  val concat: ('a list) repr -> 'a repr
+
+  val merge_bams: ([ `Bam ] list) repr -> [ `Bam ] repr
+
+  val bam_to_fastq:
+    sample_name : string ->
+    ?fragment_id : string ->
+    [ `SE | `PE ] ->
+    [ `Bam ] repr ->
+    [ `Fastq ] repr
+
   val bwa_aln:
     ?configuration: Biokepi_bfx_tools.Bwa.Configuration.Aln.t ->
     reference_build: Biokepi_run_environment.Reference_genome.name ->
@@ -52,17 +75,99 @@ module type Bioinformatics_base = sig
     [ `Fastq ] repr ->
     [ `Bam ] repr
 
-  val gunzip: [ `Gz of 'a] repr -> 'a repr
+  val star:
+    configuration: Star.Configuration.Align.t ->
+    reference_build: Biokepi_run_environment.Reference_genome.name ->
+    [ `Fastq ] repr ->
+    [ `Bam ] repr
 
-  val gunzip_concat: ([ `Gz of 'a] list) repr -> 'a repr
+  val hisat:
+    configuration: Hisat.Configuration.t ->
+    reference_build: Biokepi_run_environment.Reference_genome.name ->
+    [ `Fastq ] repr ->
+    [ `Bam ] repr
 
-  val concat: ('a list) repr -> 'a repr
+  val mosaik:
+    reference_build: Biokepi_run_environment.Reference_genome.name ->
+    [ `Fastq ] repr ->
+    [ `Bam ] repr
 
+  val stringtie:
+    configuration: Stringtie.Configuration.t ->
+    [ `Bam ] repr ->
+    [ `Gtf ] repr
 
-  val merge_bams: ([ `Bam ] list) repr -> [ `Bam ] repr
+  val gatk_indel_realigner:
+    configuration : Gatk.Configuration.indel_realigner ->
+    [ `Bam ] repr ->
+    [ `Bam ] repr
+
+  val gatk_indel_realigner_joint:
+    configuration : Gatk.Configuration.indel_realigner ->
+    ([ `Bam ] * [ `Bam ]) repr ->
+    ([ `Bam ] * [ `Bam ]) repr
+
+  val picard_mark_duplicates:
+    configuration : Picard.Mark_duplicates_settings.t ->
+    [ `Bam ] repr ->
+    [ `Bam ] repr
+
+  val gatk_bqsr:
+    configuration : Gatk.Configuration.bqsr ->
+    [ `Bam ] repr ->
+    [ `Bam ] repr
+
+  val seq2hla:
+    [ `Fastq ] repr ->
+    [ `Seq2hla_result ] repr
+
+  val optitype: 
+    [`DNA | `RNA] ->
+    [ `Fastq ] repr ->
+    [ `Optitype_result ] repr
+
+  val gatk_haplotype_caller:
+    [ `Bam ] repr ->
+    [ `Vcf ] repr
 
   val mutect:
     configuration: Biokepi_bfx_tools.Mutect.Configuration.t ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+  val mutect2:
+    configuration: Gatk.Configuration.Mutect2.t ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+  val somaticsniper:
+    configuration: Somaticsniper.Configuration.t ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+  val varscan_somatic:
+    ?adjust_mapq : int ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+  val strelka: 
+    configuration: Strelka.Configuration.t ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+  val virmid:
+    configuration: Virmid.Configuration.t ->
+    normal: [ `Bam ] repr ->
+    tumor: [ `Bam ] repr ->
+    [ `Vcf ] repr
+
+  val muse:
+    configuration: Muse.Configuration.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
     [ `Vcf ] repr

--- a/src/pipeline_edsl/to_display.ml
+++ b/src/pipeline_edsl/to_display.ml
@@ -24,6 +24,8 @@ let apply f v =
 
 let observe f = f () ~var_count:0
 
+let to_unit x = fun ~var_count -> entity SP.(x ~var_count ^^ string ":> unit")
+
 let list l =
   fun ~var_count ->
     SP.nest (OCaml.list (fun a -> a ~var_count) l)

--- a/src/pipeline_edsl/to_dot.ml
+++ b/src/pipeline_edsl/to_dot.ml
@@ -95,7 +95,18 @@ module Tree = struct
         )
         |> one
       | `Lambda (id, v, expr) ->
-        go (node ~id (sprintf "Lambda %s" v) [arrow "Expr" expr])
+        [
+          (* To be displayed subgraphs need to be called “clusterSomething” *)
+          string "subgraph" ^^ ksprintf string "cluster_%s" id ^^ braces (
+            (
+              sentence (string "color=grey")
+              :: sentence (string "style=rounded")
+              :: sentence (string "penwidth=4")
+              :: go (node ~id (sprintf "Lambda %s" v) [arrow "Expr" expr])
+            )
+            |> List.dedup |> separate empty
+          ) ^-^ newline
+        ]
       | `Apply (id, f, v) ->
         go (node ~id "Apply F(X)" [arrow "F" f; arrow "X" v])
       | `String s ->

--- a/src/pipeline_edsl/to_dot.ml
+++ b/src/pipeline_edsl/to_dot.ml
@@ -157,10 +157,12 @@ let apply f v =
 
 let observe f = f () ~var_count:0 |> Tree.to_dot
 
-  let list l =
-    fun ~var_count ->
-      Tree.node "List.make"
-        (List.mapi ~f:(fun i a -> Tree.arrow (sprintf "L%d" i) (a ~var_count)) l)
+let to_unit x = x
+
+let list l =
+  fun ~var_count ->
+    Tree.node "List.make"
+      (List.mapi ~f:(fun i a -> Tree.arrow (sprintf "L%d" i) (a ~var_count)) l)
 
 let list_map l ~f =
   fun ~var_count ->

--- a/src/pipeline_edsl/to_dot.ml
+++ b/src/pipeline_edsl/to_dot.ml
@@ -3,7 +3,6 @@ open Nonstd
 
 module Tree = struct
   type box = { id: string; name : string; attributes: (string * string) list}
-  (* type action = string *)
   type arrow = {
     label: string;
     points_to: t
@@ -87,13 +86,13 @@ module Tree = struct
           ^-^ go t
         ))
     in
-    SmartPrint.to_string 80 2 dot
+    dot
 end
 
 
 type 'a repr = var_count: int -> Tree.t
 
-type 'a observation = string
+type 'a observation = SmartPrint.t
 
 let lambda f =
   fun ~var_count ->

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -88,6 +88,16 @@ module Make_serializer (How : sig
       "reference_build", string reference_build;
       "input", fq_compiled;
     ]
+  let bwa_mem
+      ?(configuration = Tools.Bwa.Configuration.Mem.default)
+      ~reference_build fq ~var_count =
+    let fq_compiled = fq ~var_count in
+    function_call "bwa-mem" [
+      "configuration",
+      Tools.Bwa.Configuration.Mem.name configuration |> string;
+      "reference_build", string reference_build;
+      "input", fq_compiled;
+    ]
 
   let gunzip gz ~var_count =
     function_call "gunzip" ["input", gz ~var_count]

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -28,6 +28,8 @@ let apply f v =
 
 let observe f = f () ~var_count:0
 
+let to_unit j = j
+
 
 let list l =
   fun ~var_count ->

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -428,8 +428,20 @@ module Make (Config : Compiler_configuration)
         ~input_bam ~result_prefix `Map_reduce
     )
 
-  let bam_to_fastq ~sample_name ?fragment_id se_or_pe bam =
-    assert false
+  let bam_to_fastq ~sample_name ?fragment_id how bam =
+    let input_bam = get_bam bam in
+    let sample_type = match how with `SE -> `Single_end | `PE -> `Paired_end in
+    let output_prefix =
+      Config.work_dir
+      // sprintf "%s-b2fq-%s"
+        (Filename.chop_extension input_bam#product#path)
+        (match how with `PE -> "PE" | `SE -> "SE")
+    in
+    Fastq (
+      Tools.Picard.bam_to_fastq
+        ~run_with ~processors:Config.processors ~sample_type
+        ~sample_name ~output_prefix input_bam
+    )
 
   let somatic_vc name confname runfun ~configuration ~normal ~tumor =
     let normal_bam = get_bam normal in

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -11,8 +11,12 @@ module File_type_specification = struct
     | Fastq: fastq_reads workflow_node -> [ `Fastq ] t
     | Bam: bam_file workflow_node -> [ `Bam ] t
     | Vcf: single_file workflow_node -> [ `Vcf ] t
+    | Gtf: single_file workflow_node -> [ `Gtf ] t
+    | Seq2hla_result: list_of_files workflow_node -> [ `Seq2hla_result ] t
+    | Optitype_result: unknown_product workflow_node -> [ `Optitype_result ] t
     | Gz: 'a t -> [ `Gz of 'a ] t
     | List: 'a t list -> 'a list t
+    | Pair: 'a t * 'b t -> ('a * 'b) t
     | Lambda: ('a t -> 'b t) -> ('a -> 'b) t
 
   let fail_get name =
@@ -33,9 +37,39 @@ module File_type_specification = struct
   | Vcf v -> v
   | _ -> fail_get "Vcf"
 
+  let get_gtf : [ `Gtf ] t -> single_file workflow_node = function
+  | Gtf v -> v
+  | _ -> fail_get "Gtf"
+
+  let get_seq2hla_result : [ `Seq2hla_result ] t -> list_of_files workflow_node =
+    function
+    | Seq2hla_result v -> v
+    | _ -> fail_get "Seq2hla_result"
+
+  let get_optitype_result : [ `Optitype_result ] t -> unknown_product workflow_node =
+    function
+    | Optitype_result v -> v
+    | _ -> fail_get "Optitype_result"
+
   let get_gz : [ `Gz of 'a ] t -> 'a t = function
   | Gz v -> v
   | _ -> fail_get "Gz"
+
+  let get_list :  'a list  t -> 'a t list = function
+  | List v -> v
+  | _ -> fail_get "List"
+
+
+  let pair a b = Pair (a, b)
+  let pair_first =
+    function
+    | Pair (a, _) -> a
+    | other -> fail_get "Pair"
+  let pair_second =
+    function
+    | Pair (_, b) -> b
+    | other -> fail_get "Pair"
+
 end
 
 open Biokepi_run_environment
@@ -44,16 +78,24 @@ module type Compiler_configuration = sig
   val processors : int
   val work_dir: string
   val machine : Machine.t
+  val map_reduce_gatk_indel_realigner : bool
 end
+module Defaults = struct
+  let map_reduce_gatk_indel_realigner = true
+end
+
 
 module Make (Config : Compiler_configuration) 
     : Semantics.Bioinformatics_base
     with type 'a repr = 'a File_type_specification.t and
     type 'a observation = 'a File_type_specification.t
 = struct
-  open File_type_specification
+  include File_type_specification
   module Tools = Biokepi_bfx_tools
   module KEDSL = Common.KEDSL
+
+  let failf fmt =
+    ksprintf failwith fmt
 
   type 'a repr = 'a t 
   type 'a observation = 'a repr
@@ -74,6 +116,7 @@ module Make (Config : Compiler_configuration)
     | List l ->
       List (List.map ~f:(fun v -> apply f v) l)
     | _ -> assert false
+
 
   let host = Machine.as_host Config.machine
   let run_with = Config.machine
@@ -103,46 +146,90 @@ module Make (Config : Compiler_configuration)
         ~name:(sprintf "Input-bam: %s" (Filename.basename path))
     )
 
-  let bwa_aln
-      ?(configuration = Tools.Bwa.Configuration.Aln.default)
-      ~reference_build fq =
-    let freads = get_fastq fq in
+  let make_aligner
+      name ~make_workflow ~config_name
+      ~configuration ~reference_build fastq =
+    let freads = get_fastq fastq in
     let result_prefix =
       Config.work_dir // 
-      sprintf "%s-%s_bwaaln-%s"
+      sprintf "%s-%s_%s-%s"
         freads#product#escaped_sample_name
         (Option.value freads#product#fragment_id ~default:"")
-        (Tools.Bwa.Configuration.Aln.name configuration)
+        name
+        (config_name configuration)
     in
     Bam (
-      Tools.Bwa.align_to_sam ~reference_build ~processors:Config.processors
+      make_workflow
+        ~reference_build ~processors:Config.processors
         ~configuration
-        ~fastq:freads
-        ~result_prefix ~run_with ()
-      |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
+        ~result_prefix ~run_with freads
     )
+
+  let bwa_aln
+      ?(configuration = Tools.Bwa.Configuration.Aln.default) =
+    make_aligner "bwaaln" ~configuration
+      ~config_name:Tools.Bwa.Configuration.Aln.name
+      ~make_workflow:(
+        fun
+          ~reference_build ~processors
+          ~configuration ~result_prefix ~run_with freads ->
+          Tools.Bwa.align_to_sam
+            ~reference_build ~processors
+            ~configuration ~fastq:freads
+            ~result_prefix ~run_with ()
+          |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
+      )
 
   let bwa_mem
-      ?(configuration = Tools.Bwa.Configuration.Mem.default)
-      ~reference_build fq =
-    let freads = get_fastq fq in
-    let result_prefix =
-      Config.work_dir // 
-      sprintf "%s-%s_bwamem-%s"
-        freads#product#escaped_sample_name
-        (Option.value freads#product#fragment_id ~default:"")
-        (Tools.Bwa.Configuration.Mem.name configuration)
-    in
-    Bam (
-      Tools.Bwa.mem_align_to_sam ~reference_build ~processors:Config.processors
-        ~configuration
-        ~fastq:freads
-        ~result_prefix ~run_with ()
-      |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
-    )
+      ?(configuration = Tools.Bwa.Configuration.Mem.default) =
+    make_aligner "bwamem" ~configuration
+      ~config_name:Tools.Bwa.Configuration.Mem.name
+      ~make_workflow:(
+        fun
+          ~reference_build ~processors
+          ~configuration ~result_prefix ~run_with freads ->
+          Tools.Bwa.mem_align_to_sam
+            ~reference_build ~processors
+            ~configuration ~fastq:freads
+            ~result_prefix ~run_with ()
+          |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
+      )
+
+  let star =
+    make_aligner "star"
+      ~config_name:Tools.Star.Configuration.Align.name
+      ~make_workflow:(
+        fun
+          ~reference_build ~processors
+          ~configuration ~result_prefix ~run_with fastq ->
+          Tools.Star.align ~configuration ~reference_build ~processors
+            ~fastq ~result_prefix ~run_with ()
+      )
+
+  let hisat =
+    make_aligner "hisat"
+      ~config_name:Tools.Hisat.Configuration.name
+      ~make_workflow:(
+        fun
+          ~reference_build ~processors
+          ~configuration ~result_prefix ~run_with fastq ->
+          Tools.Hisat.align ~configuration ~reference_build ~processors
+            ~fastq ~result_prefix ~run_with ()
+          |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
+      )
+
+  let mosaik =
+    make_aligner "mosaik"
+      ~configuration:()
+      ~config_name:(fun _ -> "default")
+      ~make_workflow:(
+        fun
+          ~reference_build ~processors
+          ~configuration ~result_prefix ~run_with fastq ->
+          Tools.Mosaik.align ~reference_build ~processors
+            ~fastq ~result_prefix ~run_with ())
 
   let gunzip: type a. [ `Gz of a ] t -> a t = fun gz ->
-    let open KEDSL in
     let inside = get_gz gz in
     begin match inside with
     | Fastq f ->
@@ -164,25 +251,11 @@ module Make (Config : Compiler_configuration)
           ~run_with [read] ~result_path in
       let fastq_r1 = gunzip f#product#r1 in
       let fastq_r2 = Option.map f#product#r2 ~f:gunzip in
-      let product =
-        let r2 = Option.map fastq_r2 ~f:(fun r -> r#product#path) in
-        fastq_reads ~host
+      Fastq (
+        KEDSL.fastq_node_of_single_file_nodes ~host
           ~name:f#product#sample_name
           ?fragment_id:f#product#fragment_id
-          fastq_r1#product#path r2
-      in
-      let edges =
-        match fastq_r2 with
-        | Some r2 -> [depends_on fastq_r1; depends_on r2]
-        | None -> [depends_on fastq_r1]
-      in
-      Fastq (
-        workflow_node product
-          ~name:(sprintf "Gunzipped-fastq: %s (%s)" 
-                   f#product#sample_name 
-                   (Option.value f#product#fragment_id
-                      ~default:(Filename.basename fastq_r1#product#path)))
-          ~edges
+          fastq_r1 fastq_r2
       )
     | other ->
       ksprintf failwith "To_workflow.gunzip: non-FASTQ input not implemented"
@@ -191,8 +264,36 @@ module Make (Config : Compiler_configuration)
   let gunzip_concat gzl =
     ksprintf failwith "To_workflow.gunzip_concat: not implemented"
 
-  let concat l =
-    ksprintf failwith "To_workflow.concat: not implemented"
+  let concat : type a. a list t -> a t =
+    fun l ->
+      let l = get_list l in
+      begin match l with
+      | Fastq first_fastq :: _ as lfq ->
+        let fqs = List.map lfq ~f:get_fastq in
+        let r1s = List.map fqs ~f:(fun f -> f#product#r1) in
+        let r2s = List.filter_map fqs ~f:(fun f -> f#product#r2) in
+        (* TODO add some verifications that they have the same number of files?
+           i.e. that we are not mixing SE and PE fastqs
+        *)
+        let concat_files ~read l =
+          let result_path =
+            Config.work_dir //
+            sprintf "%s-Read%d-Concat.fastq"
+              first_fastq#product#escaped_sample_name read in
+          Workflow_utilities.Cat.concat ~run_with l ~result_path in
+        let read_1 = concat_files r1s ~read:1 in
+        let read_2 =
+          match r2s with [] -> None | more -> Some (concat_files more ~read:2)
+        in
+        Fastq (
+          KEDSL.fastq_node_of_single_file_nodes ~host
+            ~name:first_fastq#product#sample_name
+            ~fragment_id:"edsl-concat"
+            read_1 read_2
+        )
+      | other ->
+        ksprintf failwith "To_workflow.concat: not implemented"
+      end
 
   let merge_bams: [ `Bam ] list t -> [ `Bam ] t =
     function
@@ -211,15 +312,202 @@ module Make (Config : Compiler_configuration)
     | other ->
       fail_get "To_workflow.merge_bams: not a list of bams?"
 
-  let mutect ~configuration ~normal ~tumor =
+  let stringtie ~configuration bamt =
+    let bam = get_bam bamt in
+    let result_prefix =
+      Filename.chop_extension bam#product#path
+      ^ sprintf "_stringtie-%s"
+        (configuration.Tools.Stringtie.Configuration.name)
+    in
+    Gtf (
+      Tools.Stringtie.run
+        ~processors:Config.processors ~configuration
+        ~bam ~result_prefix ~run_with ()
+    )
+
+  let indel_realigner_function:
+    type a. configuration: _ -> a KEDSL.bam_or_bams -> a =
+    fun ~configuration on_what ->
+      match Config.map_reduce_gatk_indel_realigner with
+      | true -> 
+        Tools.Gatk.indel_realigner_map_reduce 
+          ~processors:Config.processors ~run_with ~compress:false
+          ~configuration on_what
+      | false ->
+        Tools.Gatk.indel_realigner
+          ~processors:Config.processors ~run_with ~compress:false
+          ~configuration on_what
+
+  let gatk_indel_realigner ~configuration bam =
+    let input_bam = get_bam bam in
+    Bam (indel_realigner_function ~configuration (KEDSL.Single_bam input_bam))
+
+  let gatk_indel_realigner_joint ~configuration bam_pair =
+    let bam1 = bam_pair |> pair_first |> get_bam in
+    let bam2 = bam_pair |> pair_second |> get_bam in
+    let bam_list_node =
+      indel_realigner_function (KEDSL.Bam_workflow_list [bam1; bam2])
+        ~configuration
+    in
+    begin match KEDSL.explode_bam_list_node bam_list_node with
+    | [realigned_normal; realigned_tumor] ->
+      pair (Bam realigned_normal) (Bam realigned_tumor)
+    | other ->
+      failf "Gatk.indel_realigner did not return the correct list \
+             of length 2 (tumor, normal): it gave %d bams"
+        (List.length other)
+    end
+
+  let picard_mark_duplicates ~configuration bam =
+    let input_bam = get_bam bam in
+    let output_bam = 
+      (* We assume that the settings do not impact the actual result. *)
+      Filename.chop_extension input_bam#product#path ^ "_markdup.bam" in
+    Bam (
+      Tools.Picard.mark_duplicates ~settings:configuration
+        ~run_with ~input_bam output_bam
+    )
+
+  let gatk_bqsr ~configuration bam =
+    let input_bam = get_bam bam in
+    let output_bam = 
+      let (bqsr, preads) = configuration in
+      Filename.chop_extension input_bam#product#path
+      ^ sprintf "_bqsr-B%sP%s.bam"
+        bqsr.Tools.Gatk.Configuration.Bqsr.name
+        preads.Tools.Gatk.Configuration.Print_reads.name
+    in
+    Bam (
+      Tools.Gatk.base_quality_score_recalibrator ~configuration
+        ~run_with ~processors:Config.processors ~input_bam ~output_bam
+    )
+
+  let seq2hla fq =
+    let fastq = get_fastq fq in
+    let r1 = fastq#product#r1 in
+    let r2 =
+      match fastq#product#r2 with
+      | Some r -> r
+      | None ->
+        failf "Seq2HLA doesn't support Single_end_sample(s)."
+    in
+    let work_dir =
+      Config.work_dir //
+      sprintf "%s-%s_seq2hla-workdir"
+        fastq#product#escaped_sample_name
+        fastq#product#fragment_id_forced
+    in
+    Seq2hla_result (
+      Tools.Seq2HLA.hla_type
+        ~work_dir ~run_with ~run_name:fastq#product#escaped_sample_name ~r1 ~r2
+    )
+
+  let optitype how fq =
+    let fastq = get_fastq fq in
+    let r1 = fastq#product#r1 in
+    let r2 = fastq#product#r2 in
+    let work_dir =
+      Config.work_dir //
+      sprintf "%s-%s_optitype-%s-workdir"
+        fastq#product#escaped_sample_name
+        (match how with `RNA -> "RNA" | `DNA -> "DNA")
+        fastq#product#fragment_id_forced
+    in
+    Optitype_result (
+      Tools.Optitype.hla_type
+        ~work_dir ~run_with ~run_name:fastq#product#escaped_sample_name ~r1 ?r2
+        how
+    )
+
+  let gatk_haplotype_caller bam =
+    let input_bam = get_bam bam in
+    let result_prefix =
+      Filename.chop_extension input_bam#product#path ^ sprintf "_gatkhaplo" in
+    Vcf (
+      Tools.Gatk.haplotype_caller ~run_with
+        ~input_bam ~result_prefix `Map_reduce
+    )
+
+  let bam_to_fastq ~sample_name ?fragment_id se_or_pe bam =
+    assert false
+
+  let somatic_vc name confname runfun ~configuration ~normal ~tumor =
     let normal_bam = get_bam normal in
     let tumor_bam = get_bam tumor in
     let result_prefix =
       Filename.chop_extension tumor_bam#product#path
-      ^ sprintf "_mutect-%s" (configuration.Tools.Mutect.Configuration.name)
+      ^ sprintf "_%s-%s" name (confname configuration)
     in
     Vcf (
-      Tools.Mutect.run ~configuration ~run_with
-        ~normal:normal_bam ~tumor:tumor_bam
-        ~result_prefix `Map_reduce)
+      runfun
+        ~configuration ~run_with
+        ~normal:normal_bam ~tumor:tumor_bam ~result_prefix
+    )
+
+  let mutect =
+    somatic_vc "mutect" Tools.Mutect.Configuration.name
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Mutect.run ~configuration ~run_with
+          ~normal ~tumor ~result_prefix `Map_reduce)
+
+  let mutect2 =
+    somatic_vc "mutect2" Tools.Gatk.Configuration.Mutect2.name
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Gatk.mutect2 ~configuration ~run_with
+          ~input_normal_bam:normal
+          ~input_tumor_bam:tumor
+          ~result_prefix `Map_reduce)
+
+  let somaticsniper =
+    somatic_vc "somaticsniper" Tools.Somaticsniper.Configuration.name
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Somaticsniper.run
+          ~configuration ~run_with ~normal ~tumor ~result_prefix ())
+
+  let strelka =
+    somatic_vc "strelka" Tools.Strelka.Configuration.name
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Strelka.run
+          ~configuration ~normal ~tumor
+          ~run_with ~result_prefix ~processors:Config.processors ())
+
+  let varscan_somatic ?adjust_mapq =
+    somatic_vc "varscan_somatic" (fun () ->
+        sprintf "Amq%s"
+          (Option.value_map adjust_mapq ~default:"N" ~f:Int.to_string))
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Varscan.somatic_map_reduce ?adjust_mapq
+          ~run_with ~normal ~tumor ~result_prefix ())
+      ~configuration:()
+
+  let muse =
+    somatic_vc "muse" Tools.Muse.Configuration.name
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Muse.run
+          ~configuration
+          ~run_with ~normal ~tumor ~result_prefix `Map_reduce)
+
+  let virmid =
+    somatic_vc "virmid" Tools.Virmid.Configuration.name
+      (fun
+        ~configuration ~run_with
+        ~normal ~tumor ~result_prefix ->
+        Tools.Virmid.run
+          ~configuration ~normal ~tumor
+          ~run_with ~result_prefix ~processors:Config.processors
+          ())
+
+
 end

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -476,7 +476,7 @@ module Make (Config : Compiler_configuration)
     let output_prefix =
       Config.work_dir
       // sprintf "%s-b2fq-%s"
-        (Filename.chop_extension input_bam#product#path)
+        Filename.(chop_extension (basename input_bam#product#path))
         (match how with `PE -> "PE" | `SE -> "SE")
     in
     Fastq (

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -109,13 +109,32 @@ module Make (Config : Compiler_configuration)
     let freads = get_fastq fq in
     let result_prefix =
       Config.work_dir // 
-      sprintf "%s-%s_bwa-%s"
+      sprintf "%s-%s_bwaaln-%s"
         freads#product#escaped_sample_name
         (Option.value freads#product#fragment_id ~default:"")
         (Tools.Bwa.Configuration.Aln.name configuration)
     in
     Bam (
       Tools.Bwa.align_to_sam ~reference_build ~processors:Config.processors
+        ~configuration
+        ~fastq:freads
+        ~result_prefix ~run_with ()
+      |> Tools.Samtools.sam_to_bam ~reference_build ~run_with
+    )
+
+  let bwa_mem
+      ?(configuration = Tools.Bwa.Configuration.Mem.default)
+      ~reference_build fq =
+    let freads = get_fastq fq in
+    let result_prefix =
+      Config.work_dir // 
+      sprintf "%s-%s_bwamem-%s"
+        freads#product#escaped_sample_name
+        (Option.value freads#product#fragment_id ~default:"")
+        (Tools.Bwa.Configuration.Mem.name configuration)
+    in
+    Bam (
+      Tools.Bwa.mem_align_to_sam ~reference_build ~processors:Config.processors
         ~configuration
         ~fastq:freads
         ~result_prefix ~run_with ()

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -81,6 +81,7 @@ module File_type_specification = struct
         let rec as_edges : type a. a t -> workflow_edge list = 
           let one_depends_on wf = [depends_on wf] in
           function
+          | To_unit v -> as_edges v
           | Fastq wf -> one_depends_on wf
           | Bam wf ->   one_depends_on wf
           | Vcf wf ->   one_depends_on wf

--- a/src/pipeline_edsl/transform_applications.ml
+++ b/src/pipeline_edsl/transform_applications.ml
@@ -36,6 +36,9 @@ module Apply_optimization_framework
       | Lambda : ('a term -> 'b term) -> ('a -> 'b) term
       | List_make: ('a term) list -> 'a list term
       | List_map: ('a list term * ('a -> 'b) term) -> 'b list term
+      | Pair: 'a term * 'b term -> ('a * 'b) term
+      | Fst:  ('a * 'b) term -> 'a term
+      | Snd:  ('a * 'b) term -> 'b term
     let fwd x = Unknown x
     let rec bwd : type a. a term -> a from =
       function
@@ -48,6 +51,11 @@ module Apply_optimization_framework
       | Lambda f ->
         Input.lambda (fun x -> (bwd (f (fwd x))))
       | List_make l -> Input.list (List.map ~f:bwd l)
+      | Fst (Pair (a, b)) -> bwd a
+      | Snd (Pair (a, b)) -> bwd b
+      | Pair (a, b) -> Input.pair (bwd a) (bwd b)
+      | Fst b -> Input.pair_first (bwd b)
+      | Snd b -> Input.pair_second (bwd b)
       | Unknown x -> x
   end
 
@@ -70,6 +78,9 @@ module Apply_optimization_framework
     let lambda f = Lambda f
     let list l = List_make l
     let list_map l ~f = List_map (l, f)
+    let pair a b = Pair (a, b)
+    let pair_first p = Fst p
+    let pair_second p = Snd p
   end
 
 end

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -77,6 +77,7 @@ module KEDSL = struct
     sample_name: string;
     escaped_sample_name: string;
     fragment_id: string option;
+    fragment_id_forced: string;
   >
   let fastq_reads ?host ?name ?fragment_id r1 r2_opt : fastq_reads =
     object (self)
@@ -98,6 +99,8 @@ module KEDSL = struct
       method sample_name =
         Option.value name ~default:(Filename.basename r1)
       method fragment_id = fragment_id
+      method fragment_id_forced =
+        Option.value fragment_id ~default:(Filename.basename r1)
       method escaped_sample_name =
         String.map self#sample_name ~f:(function
           | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' | '-' | '_' as c -> c

--- a/src/run_environment/machine.ml
+++ b/src/run_environment/machine.ml
@@ -92,6 +92,9 @@ module Tool = struct
       |> Option.value_exn ~msg:(sprintf "Can't find tool %s"
                                   Definition.(show def))
 
+    let concat kits =
+      { tools = List.concat_map kits ~f:(fun k -> k.tools) }
+
   end
 end
 

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -196,15 +196,17 @@ let () =
   let out = open_out pipeline_1_dot in
   SmartPrint.to_out_channel  80 2 out sm1_dot;
   close_out out;
-  (* write_file pipeline_1_dot *)
-  (*   ~content:(); *)
   let pipeline_1_svg = test_dir // "pipeline-1.svg" in
   cmdf "dot -x -Grotate=180 -v -Tsvg  %s -o %s" pipeline_1_dot pipeline_1_svg;
   let pipeline_1_png = test_dir // "pipeline-1.png" in
-  cmdf "dot -v -Tpng  %s -o %s" pipeline_1_dot pipeline_1_png;
+  cmdf "dot -v -x -Tpng  %s -o %s" pipeline_1_dot pipeline_1_png;
 
   let module Dotize_beta_reduced_pipeline_1 =
-    Pipeline_1(Biokepi.EDSL.Transform.Apply_functions(Biokepi.EDSL.Compile.To_dot))
+    Pipeline_1(
+      Biokepi.EDSL.Transform.Apply_functions(
+        Biokepi.EDSL.Transform.Apply_functions(Biokepi.EDSL.Compile.To_dot)
+      )
+    )
   in
   let pipeline_1_beta_dot = test_dir // "pipeline-1-beta.dot" in
   let sm1_beta_dot =
@@ -214,7 +216,7 @@ let () =
     let out = open_out pipeline_1_beta_dot in
     SmartPrint.to_out_channel  80 2 out sm1_beta_dot;
     close_out out;
-    cmdf "dot -v -Tpng  %s -o %s" pipeline_1_beta_dot pipeline_1_beta_png;
+    cmdf "dot -v -x -Tpng  %s -o %s" pipeline_1_beta_dot pipeline_1_beta_png;
   with e ->
     printf "BETA-DOT NOT PRODUCED !!!\n%!";
   end;

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -88,8 +88,13 @@ let () =
 
   let module Dotize_pipeline_1 = Pipeline_1(Biokepi.EDSL.Compile.To_dot) in
   let pipeline_1_dot = test_dir // "pipeline-1.dot" in
-  write_file pipeline_1_dot
-    ~content:(Dotize_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1);
+  let sm1_dot =
+    Dotize_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1 in
+  let out = open_out pipeline_1_dot in
+  SmartPrint.to_out_channel  80 2 out sm1_dot;
+  close_out out;
+  (* write_file pipeline_1_dot *)
+  (*   ~content:(); *)
   let pipeline_1_svg = test_dir // "pipeline-1.svg" in
   cmdf "dot -x -Grotate=180 -v -Tsvg  %s -o %s" pipeline_1_dot pipeline_1_svg;
   let pipeline_1_png = test_dir // "pipeline-1.png" in
@@ -99,10 +104,17 @@ let () =
     Pipeline_1(Biokepi.EDSL.Transform.Apply_functions(Biokepi.EDSL.Compile.To_dot))
   in
   let pipeline_1_beta_dot = test_dir // "pipeline-1-beta.dot" in
-  write_file pipeline_1_beta_dot
-    ~content:(Dotize_beta_reduced_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1);
+  let sm1_beta_dot =
+    Dotize_beta_reduced_pipeline_1.run ~normal:normal_1 ~tumor:tumor_1 in
   let pipeline_1_beta_png = test_dir // "pipeline-1-beta.png" in
-  cmdf "dot -v -Tpng  %s -o %s" pipeline_1_beta_dot pipeline_1_beta_png;
+  begin try
+    let out = open_out pipeline_1_beta_dot in
+    SmartPrint.to_out_channel  80 2 out sm1_beta_dot;
+    close_out out;
+    cmdf "dot -v -Tpng  %s -o %s" pipeline_1_beta_dot pipeline_1_beta_png;
+  with e ->
+    printf "BETA-DOT NOT PRODUCED !!!\n%!";
+  end;
 
   let module Workflow_compiler =
     Biokepi.EDSL.Compile.To_workflow.Make(struct

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -34,6 +34,11 @@ module Pipeline_1 (Bfx : Biokepi.EDSL.Semantics) = struct
         aligner @@ Bfx.hisat ~configuration:Biokepi.Tools.Hisat.Configuration.default_v2;
         aligner @@ Bfx.star ~configuration:Biokepi.Tools.Star.Configuration.Align.default;
         aligner @@ Bfx.mosaik;
+        aligner @@ (fun ~reference_build fastq ->
+            Bfx.bwa_aln ~reference_build fastq
+            |> Bfx.bam_to_fastq ~sample_name:"realigned" `PE
+            |> Bfx.bwa_mem ?configuration: None ~reference_build
+          );
       ] in
     let somatic_of_pair how =
       Bfx.lambda (fun pair ->


### PR DESCRIPTION
Ported everything in `Pipeline.t` to `Biokepi.EDSL`.

The test is now calling all the functions in `Semantics` in a single workflow, with a lot of `lambda`/`applly` etc.

It makes pretty crazy workflows, and the serialization of 
`Pipeline_1(Biokepi.EDSL.Transform.Apply_functions(Biokepi.EDSL.Compile.To_dot)).run`
gets `SmartPrint` into a `Stack_overflow` (on my laptop / everything else is fine).

So I had to run the test [with](http://stackoverflow.com/questions/31028681/ocamlrunparam-does-not-affect-stack-size): `ulimit -s 20000 ; OCAMLRUNPARAM=b ./biokepi-test-ttfi-pipeline`

It gets giant pictures:
- [pipeline-1](https://cloud.githubusercontent.com/assets/617111/14694668/b5378214-0738-11e6-8ed4-a6f99ff21b48.png)
- [pipeline-1-beta-ds](https://cloud.githubusercontent.com/assets/617111/14694766/a7022a2c-0739-11e6-96c3-681a2a30d8ba.png) →
the second (stack-overflow) one, I had to downsample for github to allow the upload …
(`convert _build/ttfi-test-results/pipeline-1-beta.png -sample 10% _build/ttfi-test-results/pipeline-1-beta-DS.png`)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/249)
<!-- Reviewable:end -->
