### PR TITLE
Make the optional arguments truly optional

### DIFF
--- a/src/examples/edsl_extension_register_result.ml
+++ b/src/examples/edsl_extension_register_result.ml
@@ -92,7 +92,7 @@ module Example_pipeline (Registrable_bfx: Semantics_with_registration) = struct
       |> gatk_bqsr
       |> register "final-normal-bam"
     in
-    mutect ~normal:final_normal_bam ~tumor:final_tumor_bam
+    mutect ~normal:final_normal_bam ~tumor:final_tumor_bam ()
     |> register "mutect-vcf"
 
   let run ~normal ~tumor =

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -130,20 +130,20 @@ module Generic_optimizer
   let bam_to_fastq ~sample_name ?fragment_id se_or_pe bam =
     fwd (Input.bam_to_fastq ~sample_name ?fragment_id se_or_pe (bwd bam))
 
-  let mutect ?configuration ~normal ~tumor =
-    fwd (Input.mutect ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
-  let mutect2 ?configuration ~normal ~tumor =
-    fwd (Input.mutect2 ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
-  let somaticsniper ?configuration ~normal ~tumor =
-    fwd (Input.somaticsniper ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
-  let strelka ?configuration ~normal ~tumor =
-    fwd (Input.strelka ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
-  let varscan_somatic ?adjust_mapq ~normal ~tumor =
+  let mutect ?configuration ~normal ~tumor () =
+    fwd (Input.mutect ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())
+  let mutect2 ?configuration ~normal ~tumor () =
+    fwd (Input.mutect2 ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())
+  let somaticsniper ?configuration ~normal ~tumor () =
+    fwd (Input.somaticsniper ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())
+  let strelka ?configuration ~normal ~tumor () =
+    fwd (Input.strelka ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())
+  let varscan_somatic ?adjust_mapq ~normal ~tumor () =
     fwd (Input.varscan_somatic
-           ?adjust_mapq ~normal:(bwd normal) ~tumor:(bwd tumor))
-  let muse ?configuration ~normal ~tumor =
-    fwd (Input.muse ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
-  let virmid ?configuration ~normal ~tumor =
-    fwd (Input.virmid ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor))
+           ?adjust_mapq ~normal:(bwd normal) ~tumor:(bwd tumor) ())
+  let muse ?configuration ~normal ~tumor () =
+    fwd (Input.muse ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())
+  let virmid ?configuration ~normal ~tumor () =
+    fwd (Input.virmid ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())
 
 end

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -137,42 +137,49 @@ module type Bioinformatics_base = sig
     ?configuration: Biokepi_bfx_tools.Mutect.Configuration.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
   val mutect2:
     ?configuration: Gatk.Configuration.Mutect2.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
   val somaticsniper:
     ?configuration: Somaticsniper.Configuration.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
   val varscan_somatic:
     ?adjust_mapq : int ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
   val strelka: 
     ?configuration: Strelka.Configuration.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
   val virmid:
     ?configuration: Virmid.Configuration.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
   val muse:
     ?configuration: Muse.Configuration.t ->
     normal: [ `Bam ] repr ->
     tumor: [ `Bam ] repr ->
+    unit ->
     [ `Vcf ] repr
 
 end

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -193,7 +193,7 @@ module Make_serializer (How : sig
         "input", bamc;
       ]
 
-  let variant_caller name conf_name ~normal ~tumor ~(var_count : int) =
+  let variant_caller name conf_name ~normal ~tumor () ~(var_count : int) =
     function_call name [
       "configuration", string conf_name;
       "normal", normal ~var_count;

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -494,7 +494,7 @@ module Make (Config : Compiler_configuration)
 
   let somatic_vc
       name confname default_conf runfun
-      ?configuration ~normal ~tumor =
+      ?configuration ~normal ~tumor () =
     let normal_bam = get_bam normal in
     let tumor_bam = get_bam tumor in
     let configuration = Option.value configuration ~default:default_conf in

--- a/src/test/ttfi_pipeline.ml
+++ b/src/test/ttfi_pipeline.ml
@@ -165,7 +165,7 @@ module Pipeline_insane (Bfx : Biokepi.EDSL.Semantics) = struct
       Bfx.lambda (fun pair ->
           let normal = Bfx.pair_first pair in
           let tumor = Bfx.pair_second pair in
-          how ~normal ~tumor)
+          how ~normal ~tumor ())
     in
     let somatic_vcs =
       List.map ~f:somatic_of_pair [
@@ -331,12 +331,9 @@ module Somatic_simplish(Bfx: Biokepi.EDSL.Semantics) = struct
     let vcfs =
       let normal, tumor = final_normal_bam, final_tumor_bam in
       Bfx.list [
-        Bfx.mutect ~normal ~tumor
-          ~configuration:Biokepi.Tools.Mutect.Configuration.default;
-        Bfx.somaticsniper ~normal ~tumor
-          ~configuration:Biokepi.Tools.Somaticsniper.Configuration.default;
-        Bfx.strelka ~normal ~tumor
-          ~configuration:Biokepi.Tools.Strelka.Configuration.default;
+        Bfx.mutect ~normal ~tumor ();
+        Bfx.somaticsniper ~normal ~tumor ();
+        Bfx.strelka ~normal ~tumor ();
       ] in
     Bfx.list [
       Bfx.to_unit vcfs;


### PR DESCRIPTION
This was an oversight in #256; now the variant callers take one `unit`
argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/258)
<!-- Reviewable:end -->
