### PR TITLE
Reimplement `EDSL.Library.Input.{of,to}_yojson`

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -78,6 +78,7 @@ section # Executable tests
     OCamlProgramOfFile(biokepi-test-all-downloads, $(file src/test/all_downloads.ml))
     OCamlProgramOfFile(biokepi-test-ttfi-pipeline, $(file src/test/ttfi_pipeline.ml))
     OCamlProgramOfFile(biokepi-hla-typer, $(file src/app/hla_typer.ml))
+    OCamlProgramOfFile(biokepi-edsl-input-json, $(file src/test/edsl_input_json.ml))
 
 
 DotMerlin(./src, $(LIB_PACKAGES))
@@ -103,7 +104,8 @@ build-all: lib-biokepi_run_environment \
            lib-biokepi \
            app-biokepi-demo \
            app-biokepi-tests app-biokepi-test-all-downloads \
-           app-biokepi-hla-typer  app-biokepi-test-ttfi-pipeline
+           app-biokepi-hla-typer  app-biokepi-test-ttfi-pipeline \
+           app-biokepi-edsl-input-json
 
 .PHONY: doc
 

--- a/src/pipeline_edsl/pipeline_library.ml
+++ b/src/pipeline_edsl/pipeline_library.ml
@@ -114,7 +114,7 @@ module Input = struct
       | other -> error ~json:other "Expecting {\"fragment\": ... , \"data\": ...}"
     in
     match j with
-    | `Assoc ["Biokepi_input_v0", more] ->
+    | `Assoc [vtag, more] when vtag = current_version_tag ->
       begin match more with
       | `Assoc ["Fastq",
                 `Assoc ["sample-name", `String sample; "fragments", `List frgs]] ->

--- a/src/pipeline_edsl/pipeline_library.ml
+++ b/src/pipeline_edsl/pipeline_library.ml
@@ -7,9 +7,10 @@ open Biokepi_run_environment.Common
 module Input = struct
   type t =
     | Fastq of fastq
+  and fastq_fragment = (string option * fastq_data)
   and fastq = {
     sample_name : string;
-    files : (string option * fastq_data) list; (* TODO: rename to “fragments” *)
+    files : fastq_fragment list; (* TODO: rename to “fragments” *)
   }
   and fastq_data =
     | PE of string * string

--- a/src/pipeline_edsl/pipeline_library.ml
+++ b/src/pipeline_edsl/pipeline_library.ml
@@ -9,7 +9,7 @@ module Input = struct
     | Fastq of fastq
   and fastq = {
     sample_name : string;
-    files : (string option * fastq_data) list;
+    files : (string option * fastq_data) list; (* TODO: rename to “fragments” *)
   }
   and fastq_data =
     | PE of string * string
@@ -22,6 +22,114 @@ module Input = struct
   let of_bam ?fragment_id ?sorted ~reference_build how s =
     (fragment_id, Of_bam (how, sorted, reference_build,  s))
   let fastq_sample ~sample_name files = Fastq {sample_name; files}
+
+  let tag_v0 = "Biokepi_input_v0"
+  let current_version_tag = tag_v0
+
+  let to_yojson =
+    let string s = `String s in
+    let option f o : Yojson.Safe.json = Option.value_map o ~default:`Null ~f in
+    let data_to_yojson =
+      function
+      | PE (r1, r2) ->
+        `Assoc ["PE", `Assoc ["R1", string r1; "R2", string r2]]
+      | SE f -> `Assoc ["SE", string f]
+      | Of_bam (how, sorto, refb, fil) ->
+        `Assoc ["Bam",
+                `Assoc ["kind",
+                        string (match how with `PE -> "PE" | `SE -> "SE");
+                        "sorting",
+                        (match sorto with
+                        | None  -> `Null
+                        | Some `Read_name -> `String "read-name"
+                        | Some `Coordinate -> `String "coordinate");
+                        "reference-genome", string refb;
+                        "path", string fil]]
+    in
+    let file_to_yojson (fragment_option, data) =
+      `Assoc [
+        "fragment-id", option string fragment_option;
+        "data", data_to_yojson data;
+    ] in
+    let files_to_yojson files = `List (List.map ~f:file_to_yojson files) in
+    function
+    | Fastq {sample_name; files} ->
+      `Assoc [current_version_tag,
+              `Assoc ["Fastq", `Assoc [
+                  "sample-name", string sample_name;
+                  "fragments", files_to_yojson files;
+                ]]]
+
+  let of_yojson j =
+    let open Pvem.Result in
+    let error ?json fmt =
+      ksprintf (fun s ->
+          fail (sprintf "%s%s" s
+                  (Option.value_map ~default:"" json
+                     ~f:(fun j ->
+                         sprintf " but got %s" @@
+                         Yojson.Safe.pretty_to_string ~std:true j)))
+        ) fmt in
+    let data_of_yojson =
+      function
+      | `Assoc ["PE", `Assoc ["R1", `String r1; "R2", `String r2]] ->
+        return (PE (r1, r2))
+      | `Assoc ["SE", `String file] -> SE file |> return
+      | `Assoc ["Bam", `Assoc ["kind", `String kind;
+                               "sorting", sorting;
+                               "reference-genome", `String refb;
+                               "path", `String path;]] ->
+        begin match sorting with
+        | `Null -> return None
+        | `String "coordinate" -> Some `Coordinate |> return
+        | `String "read-name" -> Some `Read_name |> return
+        | other ->
+          error ~json:other "Expecting %S, %S or null (in \"sorting\": ...)"
+            "coordinate" "read-name"
+        end
+        >>= fun sorting ->
+        begin match kind with
+        | "SE" -> return `SE
+        | "PE" -> return `PE
+        | other -> error "Kind in bam must be \"SE\" or \"PE\""
+        end
+        >>= fun kind ->
+        return (Of_bam (kind, sorting, refb, path))
+      | other ->
+        error ~json:other "Expecting string or null (in \"fragment\": ...)"
+    in
+    let fragment_of_yojson =
+      function
+      | `Assoc ["fragment-id", frag; "data", data] ->
+        begin match frag with
+        | `String s -> return (Some s)
+        | `Null -> return (None)
+        | other ->
+          error ~json:other "Expecting string or null (in \"fragment\": ...)"
+        end
+        >>= fun fragment_id ->
+        data_of_yojson data
+        >>= fun data_parsed ->
+        return (fragment_id, data_parsed)
+      | other -> error ~json:other "Expecting {\"fragment\": ... , \"data\": ...}"
+    in
+    match j with
+    | `Assoc ["Biokepi_input_v0", more] ->
+      begin match more with
+      | `Assoc ["Fastq",
+                `Assoc ["sample-name", `String sample; "fragments", `List frgs]] ->
+        List.fold ~init:(return []) frgs ~f:(fun prev frag ->
+            prev >>= fun p ->
+            fragment_of_yojson frag
+            >>= fun more ->
+            return (more :: p))
+        >>= fun l ->
+        return (Fastq { sample_name = sample; files = List.rev l })
+      | other ->
+        error ~json:other "Expecting Fastq"
+      end
+    | other ->
+      error ~json:other "Expecting Biokepi_input_v0"
 end
 
 module Make (Bfx : Semantics.Bioinformatics_base) = struct

--- a/src/pipeline_edsl/pipeline_library.mli
+++ b/src/pipeline_edsl/pipeline_library.mli
@@ -1,0 +1,40 @@
+
+
+module Input : sig
+
+  type t
+  type fastq_fragment
+
+  val pp : Format.formatter -> t -> unit
+  val show : t -> string
+
+  val pe : ?fragment_id:string -> string -> string -> fastq_fragment
+
+  val se : ?fragment_id:string -> string -> fastq_fragment
+
+  val of_bam :
+    ?fragment_id: string ->
+    ?sorted:[ `Coordinate | `Read_name ] ->
+    reference_build:string ->
+    [ `PE | `SE ] -> string -> fastq_fragment
+
+  val fastq_sample :
+    sample_name:string -> fastq_fragment list -> t
+
+  val to_yojson : t -> Yojson.Safe.json
+  val of_yojson : Yojson.Safe.json -> (t, string) Pvem.Result.t
+
+end
+
+module Make:
+  functor (Bfx : Semantics.Bioinformatics_base) ->
+  sig
+
+    val fastq_of_files :
+      sample_name:string ->
+      ?fragment_id:string ->
+      r1:string -> ?r2:string -> unit -> [ `Fastq ] Bfx.repr
+
+    val fastq_of_input : Input.t -> [ `Fastq ] list Bfx.repr
+
+  end

--- a/src/test/edsl_input_json.ml
+++ b/src/test/edsl_input_json.ml
@@ -1,0 +1,43 @@
+
+open Nonstd
+module String = Sosa.Native_string
+open Biokepi.EDSL.Library.Input
+
+
+let examples = [
+  "1", fastq_sample ~sample_name:"Sample1" [];
+  "2", fastq_sample ~sample_name:"Sample2" [
+    pe ~fragment_id:"frg1" "frg1R1.fastq" "frg1R2.fastq";
+    se ~fragment_id:"frg2" "frg2.fastq";
+    of_bam  ~sorted:`Coordinate ~reference_build:"b37" `PE "n2.bam";
+  ];
+  "3", fastq_sample ~sample_name:"Sample3" [
+    pe "frg1R1.fastq" "frg1R2.fastq";
+    se "frg2.fastq";
+    of_bam  ~sorted:`Read_name ~reference_build:"b37" `SE "n2.bam";
+  ];
+]
+
+let () =
+  let print_them = try Sys.argv.(1) = "print" with _ -> false in
+  List.iter examples ~f:(fun (name, ex) ->
+      let json = to_yojson ex in
+      let result = of_yojson json in
+      let print_both () =
+        sprintf "JSON ->\n%s\nPARSED-TO:\n%s\n"
+          (Yojson.Safe.pretty_to_string ~std:true json)
+          (match result with
+          | `Ok o -> show o
+          | `Error s -> sprintf "ERROR: %s" s)
+      in
+      printf "Example %S: %s\n%!" name
+        begin match result with
+        | `Ok o when o = ex -> sprintf "OK and Equal"
+        | `Ok o -> sprintf "OK but NOT EQUAL\n%s" (print_both ())
+        | `Error e -> sprintf "ERROR:\n%s" (print_both ())
+        end;
+      if print_them
+      then
+        printf "\n```````````````json\n%s\n```````````````\n\n%!"
+          (Yojson.Safe.pretty_to_string ~std:true json);
+    )


### PR DESCRIPTION
The idea is to have a more durable, versioned JSON format and parse it
manually to an `Input.t`.

There is a test: `src/test/edsl_input_json.ml`; calling
`./biokepi-edsl-input-json print` additionally shows some examples:

Example "1":

```````````````json
{
  "Biokepi_input_v0": {
    "Fastq": { "sample-name": "Sample1", "fragments": [] }
  }
}
```````````````

Example "2":

```````````````json
{
  "Biokepi_input_v0": {
    "Fastq": {
      "sample-name": "Sample2",
      "fragments": [
        {
          "fragment-id": "frg1",
          "data": { "PE": { "R1": "frg1R1.fastq", "R2": "frg1R2.fastq" } }
        },
        { "fragment-id": "frg2", "data": { "SE": "frg2.fastq" } },
        {
          "fragment-id": null,
          "data": {
            "Bam": {
              "kind": "PE",
              "sorting": "coordinate",
              "reference-genome": "b37",
              "path": "n2.bam"
            }
          }
        }
      ]
    }
  }
}
```````````````

Example "3":

```````````````json
{
  "Biokepi_input_v0": {
    "Fastq": {
      "sample-name": "Sample3",
      "fragments": [
        {
          "fragment-id": null,
          "data": { "PE": { "R1": "frg1R1.fastq", "R2": "frg1R2.fastq" } }
        },
        { "fragment-id": null, "data": { "SE": "frg2.fastq" } },
        {
          "fragment-id": null,
          "data": {
            "Bam": {
              "kind": "SE",
              "sorting": "read-name",
              "reference-genome": "b37",
              "path": "n2.bam"
            }
          }
        }
      ]
    }
  }
}
```````````````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/296)
<!-- Reviewable:end -->
