### PR TITLE
Add `EDSL.mhc_alleles` input function

### DIFF
--- a/src/bfx_tools/topiary.ml
+++ b/src/bfx_tools/topiary.ml
@@ -138,7 +138,7 @@ let run ~(run_with: Machine.t)
   in
   let var_arg = ["--vcf"; variants_vcf#product#path] in
   let predictor_arg = ["--mhc-predictor"; (predictor_to_string predictor)] in
-  let allele_arg = ["--mhc-alleles-file"; alleles_file] in
+  let allele_arg = ["--mhc-alleles-file"; alleles_file#product#path] in
   let (output_arg, output_path) = 
     match output with
     | `HTML html_file -> ["--output-html"; html_file], html_file
@@ -182,6 +182,7 @@ let run ~(run_with: Machine.t)
       depends_on Machine.Tool.(ensure topiary);
       depends_on (Pyensembl.cache_genome ~run_with ~reference_build);
       depends_on variants_vcf;
+      depends_on alleles_file;
     ]
     ~make:(
       Machine.run_program run_with ~name

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -75,6 +75,8 @@ module Generic_optimizer
   let bam ~path ?sorting ~reference_build () =
     fwd (Input.bam ~path ?sorting ~reference_build ())
 
+  let mhc_alleles how = fwd (Input.mhc_alleles how)
+
   let bwa_aln ?configuration ~reference_build fq =
     fwd (Input.bwa_aln ?configuration ~reference_build (bwd fq))
 
@@ -154,6 +156,7 @@ module Generic_optimizer
   let isovar ?configuration reference_build vcf bam =
     fwd (Input.isovar ?configuration reference_build (bwd vcf) (bwd bam))
   let topiary ?configuration reference_build vcf predictor alleles = 
-    fwd (Input.topiary ?configuration reference_build (bwd vcf) predictor alleles)
+    fwd (Input.topiary
+           ?configuration reference_build (bwd vcf) predictor (bwd alleles))
 
 end

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -49,7 +49,8 @@ module type Bioinformatics_base = sig
     reference_build: string ->
     unit -> [ `Bam ] repr
 
-
+  (** Input a file containing HLA allelles for Topiary  *)
+  val mhc_alleles: [ `File of string | `Names of string list] -> [ `MHC_alleles ] repr
 
   val gunzip: [ `Gz of 'a] repr -> 'a repr
 
@@ -203,7 +204,7 @@ module type Bioinformatics_base = sig
     Biokepi_run_environment.Reference_genome.name ->
     [ `Vcf ] repr ->
     Topiary.predictor_type ->
-    string ->
+    [ `MHC_alleles ] repr ->
     [ `Topiary ] repr
 
 end

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -79,6 +79,13 @@ module Make_serializer (How : sig
       "reference_build", reference_build;
     ]
 
+  let mhc_alleles how =
+    input_value "mhc_alleles" [
+      match how with
+      | `File p -> "path", p
+      | `Names sl -> "inline", (String.concat ", " sl)
+      ]
+
   let pair a b ~(var_count : int) =
     function_call "make-pair" [
       "first", a ~var_count;
@@ -189,7 +196,7 @@ module Make_serializer (How : sig
       let vcf_compiled = vcf ~var_count in
       function_call "topiary" [
         "configuration", string Tools.Topiary.Configuration.(name configuration);
-        "alleles", string alleles;
+        "alleles", alleles ~var_count;
         "reference_build", string reference_build;
         "predictor", string Tools.Topiary.(predictor_to_string predictor);
         "vcf", vcf_compiled;


### PR DESCRIPTION
This creates a new functions in the EDSL that is used to input MHC
Alleles for Topiary.

One can give a file name; or input directly allele names.

This is a follow up to #268.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/300)
<!-- Reviewable:end -->
