### PR TITLE
Force PyEnsembl to cache into a shared location

### DIFF
--- a/src/bfx_tools/isovar.ml
+++ b/src/bfx_tools/isovar.ml
@@ -61,6 +61,7 @@ let run ~(run_with: Machine.t)
       Machine.run_program run_with ~name
         Program.(
           Machine.Tool.(init isovar_tool)
+          && Pyensembl.(set_cache_dir_command ~run_with)
           && sh isovar_cmd
         )
     )

--- a/src/bfx_tools/pyensembl.ml
+++ b/src/bfx_tools/pyensembl.ml
@@ -1,13 +1,22 @@
 open Biokepi_run_environment
 open Common
 
+let set_cache_dir_command ~(run_with: Machine.t) ~reference_build =
+  let open KEDSL in
+  let env_var = "PYENSEMBL_CACHE_DIR" in
+  let cache_dir = Machine.(get_pyensembl_cache_dir run_with) in
+  let cache_dir_value = 
+    match cache_dir with
+      | Some d -> d
+      | None -> ""
+  in
+  Program.(shf "export %s='%s'" env_var cache_dir_value)
+
 let cache_genome ~(run_with: Machine.t) ~reference_build =
   let open KEDSL in
   let pyensembl =
     Machine.get_tool run_with Machine.Tool.Definition.(create "pyensembl")
   in
-  let ref_genome_dir = Machine.(get_reference_genome_dir run_with) in
-  let cache_dir = ref_genome_dir // "pyensembl" in
   let genome = Machine.(get_reference_genome run_with reference_build) in
   let ensembl_release = genome |> Reference_genome.ensembl in
   let species = genome |> Reference_genome.species in
@@ -24,7 +33,7 @@ let cache_genome ~(run_with: Machine.t) ~reference_build =
         ~name
         Program.(
           Machine.Tool.(init pyensembl)
-          && shf "export PYENSEMBL_CACHE_DIR='%s'" cache_dir
+          && (set_cache_dir_command ~run_with ~reference_build)
           && shf "pyensembl install --release %d --species \"%s\""
              ensembl_release
              species

--- a/src/bfx_tools/pyensembl.ml
+++ b/src/bfx_tools/pyensembl.ml
@@ -1,9 +1,10 @@
 open Biokepi_run_environment
 open Common
 
+let pyensembl_env_key = "PYENSEMBL_CACHE_DIR"
+
 let set_cache_dir_command ~(run_with: Machine.t) =
   let open KEDSL in
-  let env_var = "PYENSEMBL_CACHE_DIR" in
   let cache_dir = Machine.(get_pyensembl_cache_dir run_with) in
   let cache_dir_value = 
     match cache_dir with
@@ -11,7 +12,7 @@ let set_cache_dir_command ~(run_with: Machine.t) =
       | None -> failwith "Tool depends on PyEnsembl, but the cache directory \
                           has not been set!"
   in
-  Program.(shf "export %s='%s'" env_var cache_dir_value)
+  Program.(shf "export %s='%s'" pyensembl_env_key cache_dir_value)
 
 let cache_genome ~(run_with: Machine.t) ~reference_build =
   let open KEDSL in
@@ -21,9 +22,12 @@ let cache_genome ~(run_with: Machine.t) ~reference_build =
   let genome = Machine.(get_reference_genome run_with reference_build) in
   let ensembl_release = genome |> Reference_genome.ensembl in
   let species = genome |> Reference_genome.species in
+  let witness_file_path = 
+    sprintf "${%s}/%s.cached" pyensembl_env_key reference_build
+  in
   let name = sprintf "pyensembl_cache-%d-%s" ensembl_release species in
   workflow_node
-    without_product
+    (single_file witness_file_path ~host:(Machine.as_host run_with))
     ~name
     ~edges:[
       depends_on Machine.Tool.(ensure pyensembl);
@@ -38,5 +42,6 @@ let cache_genome ~(run_with: Machine.t) ~reference_build =
           && shf "pyensembl install --release %d --species \"%s\""
              ensembl_release
              species
+          && exec ["touch"; witness_file_path]
         )
     )

--- a/src/bfx_tools/pyensembl.ml
+++ b/src/bfx_tools/pyensembl.ml
@@ -6,6 +6,8 @@ let cache_genome ~(run_with: Machine.t) ~reference_build =
   let pyensembl =
     Machine.get_tool run_with Machine.Tool.Definition.(create "pyensembl")
   in
+  let ref_genome_dir = Machine.(get_reference_genome_dir run_with) in
+  let cache_dir = ref_genome_dir // "pyensembl" in
   let genome = Machine.(get_reference_genome run_with reference_build) in
   let ensembl_release = genome |> Reference_genome.ensembl in
   let species = genome |> Reference_genome.species in
@@ -22,6 +24,7 @@ let cache_genome ~(run_with: Machine.t) ~reference_build =
         ~name
         Program.(
           Machine.Tool.(init pyensembl)
+          && shf "export PYENSEMBL_CACHE_DIR='%s'" cache_dir
           && shf "pyensembl install --release %d --species \"%s\""
              ensembl_release
              species

--- a/src/bfx_tools/pyensembl.ml
+++ b/src/bfx_tools/pyensembl.ml
@@ -1,14 +1,15 @@
 open Biokepi_run_environment
 open Common
 
-let set_cache_dir_command ~(run_with: Machine.t) ~reference_build =
+let set_cache_dir_command ~(run_with: Machine.t) =
   let open KEDSL in
   let env_var = "PYENSEMBL_CACHE_DIR" in
   let cache_dir = Machine.(get_pyensembl_cache_dir run_with) in
   let cache_dir_value = 
     match cache_dir with
       | Some d -> d
-      | None -> ""
+      | None -> failwith "Tool depends on PyEnsembl, but the cache directory \
+                          has not been set!"
   in
   Program.(shf "export %s='%s'" env_var cache_dir_value)
 
@@ -33,7 +34,7 @@ let cache_genome ~(run_with: Machine.t) ~reference_build =
         ~name
         Program.(
           Machine.Tool.(init pyensembl)
-          && (set_cache_dir_command ~run_with ~reference_build)
+          && (set_cache_dir_command ~run_with)
           && shf "pyensembl install --release %d --species \"%s\""
              ensembl_release
              species

--- a/src/bfx_tools/topiary.ml
+++ b/src/bfx_tools/topiary.ml
@@ -188,6 +188,7 @@ let run ~(run_with: Machine.t)
       Machine.run_program run_with ~name
         Program.(
           Machine.Tool.(init topiary)
+          && Pyensembl.(set_cache_dir_command ~run_with ~reference_build)
           && exec (["topiary"] @ arguments)
         )
     )

--- a/src/bfx_tools/topiary.ml
+++ b/src/bfx_tools/topiary.ml
@@ -188,7 +188,7 @@ let run ~(run_with: Machine.t)
       Machine.run_program run_with ~name
         Program.(
           Machine.Tool.(init topiary)
-          && Pyensembl.(set_cache_dir_command ~run_with ~reference_build)
+          && Pyensembl.(set_cache_dir_command ~run_with)
           && exec (["topiary"] @ arguments)
         )
     )

--- a/src/bfx_tools/vaxrank.ml
+++ b/src/bfx_tools/vaxrank.ml
@@ -176,6 +176,7 @@ let run ~(run_with: Machine.t)
       Machine.run_program run_with ~name
         Program.(
           Machine.Tool.(init vaxrank)
+          && Pyensembl.(set_cache_dir_command ~run_with)
           && exec (["vaxrank"] @ arguments)
         )
     )

--- a/src/environment_setup/build_machine.ml
+++ b/src/environment_setup/build_machine.ml
@@ -11,11 +11,11 @@ let create
     ?(max_processors = 1)
     ?gatk_jar_location
     ?mutect_jar_location
+    ?(pyensembl_cache_dir = None)
     ?run_program ?toolkit ?b37 uri =
   let open KEDSL in
   let host = Host.parse (uri // "ketrew_playground") in
   let meta_playground = Uri.of_string uri |> Uri.path in
-  let reference_genome_dir = meta_playground // "reference-genome" in
   let run_program =
     match run_program with
     | None -> default_run_program ~host
@@ -30,14 +30,14 @@ let create
   in
   Machine.create (sprintf "ssh-box-%s" uri)
     ~max_processors
-    ~reference_genome_dir
+    ~pyensembl_cache_dir
     ~get_reference_genome:(fun name ->
         match name, b37 with
         | name, Some some37 when name = Reference_genome.name some37 -> some37
         | name, _ ->        
           Download_reference_genomes.get_reference_genome name
             ~toolkit ~host ~run_program
-            ~destination_path:reference_genome_dir)
+            ~destination_path:(meta_playground // "reference-genome"))
     ~host
     ~toolkit
     ~run_program

--- a/src/environment_setup/build_machine.ml
+++ b/src/environment_setup/build_machine.ml
@@ -11,7 +11,7 @@ let create
     ?(max_processors = 1)
     ?gatk_jar_location
     ?mutect_jar_location
-    ?(pyensembl_cache_dir = None)
+    ?pyensembl_cache_dir
     ?run_program ?toolkit ?b37 uri =
   let open KEDSL in
   let host = Host.parse (uri // "ketrew_playground") in
@@ -30,7 +30,7 @@ let create
   in
   Machine.create (sprintf "ssh-box-%s" uri)
     ~max_processors
-    ~pyensembl_cache_dir
+    ?pyensembl_cache_dir
     ~get_reference_genome:(fun name ->
         match name, b37 with
         | name, Some some37 when name = Reference_genome.name some37 -> some37

--- a/src/environment_setup/build_machine.ml
+++ b/src/environment_setup/build_machine.ml
@@ -15,6 +15,7 @@ let create
   let open KEDSL in
   let host = Host.parse (uri // "ketrew_playground") in
   let meta_playground = Uri.of_string uri |> Uri.path in
+  let reference_genome_dir = meta_playground // "reference-genome" in
   let run_program =
     match run_program with
     | None -> default_run_program ~host
@@ -29,13 +30,14 @@ let create
   in
   Machine.create (sprintf "ssh-box-%s" uri)
     ~max_processors
+    ~reference_genome_dir
     ~get_reference_genome:(fun name ->
         match name, b37 with
         | name, Some some37 when name = Reference_genome.name some37 -> some37
         | name, _ ->        
           Download_reference_genomes.get_reference_genome name
             ~toolkit ~host ~run_program
-            ~destination_path:(meta_playground // "reference-genome"))
+            ~destination_path:reference_genome_dir)
     ~host
     ~toolkit
     ~run_program

--- a/src/environment_setup/build_machine.mli
+++ b/src/environment_setup/build_machine.mli
@@ -23,7 +23,7 @@ val create :
   ?max_processors : int ->
   ?gatk_jar_location:(unit -> Tool_providers.broad_jar_location) ->
   ?mutect_jar_location:(unit -> Tool_providers.broad_jar_location) ->
-  ?pyensembl_cache_dir:string option ->
+  ?pyensembl_cache_dir:string ->
   ?run_program:Machine.Make_fun.t ->
   ?toolkit:Machine.Tool.Kit.t ->
   ?b37:Reference_genome.t ->

--- a/src/environment_setup/build_machine.mli
+++ b/src/environment_setup/build_machine.mli
@@ -23,6 +23,7 @@ val create :
   ?max_processors : int ->
   ?gatk_jar_location:(unit -> Tool_providers.broad_jar_location) ->
   ?mutect_jar_location:(unit -> Tool_providers.broad_jar_location) ->
+  ?pyensembl_cache_dir:string option ->
   ?run_program:Machine.Make_fun.t ->
   ?toolkit:Machine.Tool.Kit.t ->
   ?b37:Reference_genome.t ->

--- a/src/environment_setup/python_package.ml
+++ b/src/environment_setup/python_package.ml
@@ -58,7 +58,7 @@ let create_python_tool ~host ~(run_program : Machine.Make_fun.t) ~install_path
 let default ~host ~run_program ~install_path () =
    Machine.Tool.Kit.of_list [
     create_python_tool ~host ~run_program ~install_path 
-      ~version:"0.9.3" (Pip, Package_PyPI "pyensembl");
+      ~version:"0.9.4" (Pip, Package_PyPI "pyensembl");
     create_python_tool ~host ~run_program ~install_path 
       ~version:"0.1.2" (Pip, Package_PyPI "vcf-annotate-polyphen");
     create_python_tool ~host ~run_program ~install_path 

--- a/src/run_environment/machine.ml
+++ b/src/run_environment/machine.ml
@@ -164,6 +164,7 @@ end
 type t = {
   name: string;
   host: Host.t;
+  reference_genome_dir: string;
   get_reference_genome: string -> Reference_genome.t;
   toolkit: Tool.Kit.t;
   run_program: Make_fun.t;
@@ -171,13 +172,14 @@ type t = {
   max_processors: int;
 }
 let create
-    ~host ~get_reference_genome ~toolkit
+    ~host ~reference_genome_dir ~get_reference_genome ~toolkit
     ~run_program ~work_dir ~max_processors  name =
-  {name; toolkit; get_reference_genome; host;
-   run_program; work_dir; max_processors}
+  {name; toolkit; reference_genome_dir; get_reference_genome;
+   host; run_program; work_dir; max_processors}
 
 let name t = t.name
 let as_host t = t.host
+let get_reference_genome_dir t = t.reference_genome_dir
 let get_reference_genome t = t.get_reference_genome
 let get_tool t tool =
   match t.toolkit tool with

--- a/src/run_environment/machine.ml
+++ b/src/run_environment/machine.ml
@@ -172,7 +172,7 @@ type t = {
   max_processors: int;
 }
 let create
-    ~host ~pyensembl_cache_dir ~get_reference_genome ~toolkit
+    ~host ?pyensembl_cache_dir ~get_reference_genome ~toolkit
     ~run_program ~work_dir ~max_processors  name =
   {name; toolkit; pyensembl_cache_dir; get_reference_genome;
    host; run_program; work_dir; max_processors}

--- a/src/run_environment/machine.ml
+++ b/src/run_environment/machine.ml
@@ -164,7 +164,7 @@ end
 type t = {
   name: string;
   host: Host.t;
-  reference_genome_dir: string;
+  pyensembl_cache_dir: string option;
   get_reference_genome: string -> Reference_genome.t;
   toolkit: Tool.Kit.t;
   run_program: Make_fun.t;
@@ -172,14 +172,14 @@ type t = {
   max_processors: int;
 }
 let create
-    ~host ~reference_genome_dir ~get_reference_genome ~toolkit
+    ~host ~pyensembl_cache_dir ~get_reference_genome ~toolkit
     ~run_program ~work_dir ~max_processors  name =
-  {name; toolkit; reference_genome_dir; get_reference_genome;
+  {name; toolkit; pyensembl_cache_dir; get_reference_genome;
    host; run_program; work_dir; max_processors}
 
 let name t = t.name
 let as_host t = t.host
-let get_reference_genome_dir t = t.reference_genome_dir
+let get_pyensembl_cache_dir t = t.pyensembl_cache_dir
 let get_reference_genome t = t.get_reference_genome
 let get_tool t tool =
   match t.toolkit tool with


### PR DESCRIPTION
So that each PyGenomics tool can use the same shared cached files if necessary.

More information on setting up the cache folder: https://github.com/hammerlab/pyensembl#cache-location

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/303)
<!-- Reviewable:end -->
