### PR TITLE
add sample_name to bam_file

### DIFF
--- a/src/bfx_tools/bedtools.ml
+++ b/src/bfx_tools/bedtools.ml
@@ -31,6 +31,7 @@ let bamtofastq
   let sorted_bam =
     Samtools.sort_bam_if_necessary
       ~run_with ~by:`Read_name input_bam in
+  let sample_name = input_bam#product#sample_name in
   let fastq_output_options, r1, r2opt =
     match sample_type with
     | `Paired_end ->
@@ -66,7 +67,7 @@ let bamtofastq
     end
   in
   workflow_node
-    (fastq_reads ~host:(Machine.as_host run_with) r1 r2opt)
+    (fastq_reads ~name:sample_name ~host:(Machine.as_host run_with) r1 r2opt)
     ~edges ~name ~make
 
 

--- a/src/bfx_tools/picard.ml
+++ b/src/bfx_tools/picard.ml
@@ -150,12 +150,12 @@ let mark_duplicates
       on_failure_activate (Remove.file ~run_with metrics_path);
     ]
 
-let bam_to_fastq
-    ?sample_name ~run_with ~sample_type ~output_prefix input_bam =
+let bam_to_fastq ~run_with ~sample_type ~output_prefix input_bam =
   let open KEDSL in
   let sorted_bam =
     Samtools.sort_bam_if_necessary
       ~run_with ~by:`Read_name input_bam in
+  let sample_name = input_bam#product#sample_name in
   let fastq_output_options, r1, r2opt =
     match sample_type with
     | `Paired_end ->
@@ -194,5 +194,5 @@ let bam_to_fastq
       ]
   in
   workflow_node
-    (fastq_reads ?name:sample_name ~host:(Machine.as_host run_with) r1 r2opt)
+    (fastq_reads ~name:sample_name ~host:(Machine.as_host run_with) r1 r2opt)
     ~name ~make ~edges

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -72,8 +72,8 @@ module Generic_optimizer
   let fastq_gz ~sample_name ?fragment_id ~r1 ?r2 () =
     fwd (Input.fastq_gz ~sample_name ?fragment_id ~r1 ?r2 ())
 
-  let bam ~path ?sorting ~reference_build () =
-    fwd (Input.bam ~path ?sorting ~reference_build ())
+  let bam ~path ~sample_name ?sorting ~reference_build () =
+    fwd (Input.bam ~path ~sample_name ?sorting ~reference_build ())
 
   let mhc_alleles how = fwd (Input.mhc_alleles how)
 
@@ -129,8 +129,8 @@ module Generic_optimizer
   let merge_bams bl =
     fwd (Input.merge_bams (bwd bl))
 
-  let bam_to_fastq ~sample_name ?fragment_id se_or_pe bam =
-    fwd (Input.bam_to_fastq ~sample_name ?fragment_id se_or_pe (bwd bam))
+  let bam_to_fastq ?fragment_id se_or_pe bam =
+    fwd (Input.bam_to_fastq ?fragment_id se_or_pe (bwd bam))
 
   let mutect ?configuration ~normal ~tumor () =
     fwd (Input.mutect ?configuration ~normal:(bwd normal) ~tumor:(bwd tumor) ())

--- a/src/pipeline_edsl/pipeline.ml
+++ b/src/pipeline_edsl/pipeline.ml
@@ -77,7 +77,7 @@ type _ t =
   | Fastq: File.t -> fastq  t
   (* | List: 'a t list -> 'a list t *)
   | Bam_sample: string * bam -> bam t
-  | Bam_to_fastq: fastq_sample_info option * [ `Single | `Paired ] * bam t -> fastq_sample t
+  | Bam_to_fastq: [ `Single | `Paired ] * bam t -> fastq_sample t
   | Paired_end_sample: fastq_sample_info * fastq t * fastq t -> fastq_sample t
   | Single_end_sample: fastq_sample_info * fastq t -> fastq_sample t
   | Gunzip_concat: fastq_gz t list -> fastq t
@@ -137,7 +137,7 @@ module Construct = struct
 
   let bam ~dataset bam = Bam_sample (dataset, bam)
 
-  let bam_to_fastq ?sample_name how bam = Bam_to_fastq (sample_name, how, bam)
+  let bam_to_fastq how bam = Bam_to_fastq (how, bam)
 
   let bwa ?(configuration = Bwa.Configuration.Aln.default) fastq =
     Bwa (configuration, fastq)
@@ -346,7 +346,7 @@ let rec to_file_prefix:
       end
     | Concat_text _ -> failwith "TODO"
     | Bam_sample (name, _) -> Filename.basename name
-    | Bam_to_fastq (_, how, bam) ->
+    | Bam_to_fastq (how, bam) ->
       sprintf "%s-b2fq-%s"
         (to_file_prefix bam)
         (match how with `Paired -> "PE" | `Single -> "SE")
@@ -413,7 +413,7 @@ let rec to_json: type a. a t -> json =
     | Fastq file -> call "Fastq" [`String file#product#path]
     | Bam_sample (name, file) ->
       call "Bam-sample" [`String name; `String file#product#path]
-    | Bam_to_fastq (name, how, bam) ->
+    | Bam_to_fastq (how, bam) ->
       let how_string =
         match how with `Paired -> "Paired" | `Single -> "Single" in
       call "Bam-to-fastq" [`String how_string; to_json bam]
@@ -579,15 +579,13 @@ module Compiler = struct
     let {work_dir; machine ; _ } = compiler in
 
       match fs with
-      | Bam_to_fastq (info_opt, how, what) ->
+      | Bam_to_fastq (how, what) ->
         let bam = compile_aligner_step ~compiler what in
         let sample_type =
           match how with `Single -> `Single_end | `Paired -> `Paired_end in
         let fastq_pair =
           let output_prefix = work_dir // to_file_prefix ?read:None what in
-          let sample_name = Option.map info_opt (fun x -> x.sample_name) in
           Picard.bam_to_fastq ~run_with:machine ~sample_type
-            ?sample_name
             ~output_prefix bam
         in
         fastq_pair

--- a/src/pipeline_edsl/pipeline_library.ml
+++ b/src/pipeline_edsl/pipeline_library.ml
@@ -168,8 +168,8 @@ module Make (Bfx : Semantics.Bioinformatics_base) = struct
           | SE r ->
             fastq_of_files ~sample_name ?fragment_id ~r1:r  ()
           | Of_bam (how, sorting, reference_build, path) ->
-            let bam = Bfx.bam ~path ?sorting ~reference_build () in
-            Bfx.bam_to_fastq ~sample_name ?fragment_id how bam
+            let bam = Bfx.bam ~path ~sample_name ?sorting ~reference_build () in
+            Bfx.bam_to_fastq ?fragment_id how bam
         )
       |> Bfx.list
 

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -45,6 +45,7 @@ module type Bioinformatics_base = sig
 
   val bam :
     path : string ->
+    sample_name : string ->
     ?sorting: [ `Coordinate | `Read_name ] ->
     reference_build: string ->
     unit -> [ `Bam ] repr
@@ -61,7 +62,6 @@ module type Bioinformatics_base = sig
   val merge_bams: ([ `Bam ] list) repr -> [ `Bam ] repr
 
   val bam_to_fastq:
-    sample_name : string ->
     ?fragment_id : string ->
     [ `SE | `PE ] ->
     [ `Bam ] repr ->

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -70,9 +70,10 @@ module Make_serializer (How : sig
       "R2", Option.value ~default:"NONE" r2;
     ]
 
-  let bam ~path ?sorting ~reference_build () =
+  let bam ~path ~sample_name ?sorting ~reference_build () =
     input_value "bam" [
       "path", path;
+      "sample_name", sample_name;
       "sorting",
       Option.value_map ~default:"NONE" sorting
         ~f:(function `Coordinate -> "Coordinate" | `Read_name -> "Read-name");
@@ -208,11 +209,10 @@ module Make_serializer (How : sig
   let gatk_haplotype_caller =
     one_to_one "gatk_haplotype_caller" "default"
 
-  let bam_to_fastq ~sample_name ?fragment_id se_or_pe bam =
+  let bam_to_fastq ?fragment_id se_or_pe bam =
     fun ~(var_count : int) ->
       let bamc = bam ~var_count in
       function_call "bam_to_fastq" [
-        "sample_name", string sample_name;
         "fragment_id",
         Option.value_map ~f:string ~default:(string "N/A") fragment_id;
         "endness", string (

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -276,12 +276,12 @@ module Make (Config : Compiler_configuration)
         ~sample_name ?fragment_id ~r1 ?r2 ()
     )
 
-  let bam ~path ?sorting ~reference_build () =
+  let bam ~path ~sample_name ?sorting ~reference_build () =
     Bam (
       let open KEDSL in
       let host = Machine.as_host Config.machine in
       let make_product path =
-        bam_file ~host ?sorting ~reference_build path in
+        bam_file ~host ~name:sample_name ?sorting ~reference_build path in
       let input =
         workflow_node (make_product path)
           ~name:(sprintf "Input-bam: %s" (Filename.basename path)) in
@@ -655,7 +655,7 @@ module Make (Config : Compiler_configuration)
         ~input_bam ~result_prefix `Map_reduce
     )
 
-  let bam_to_fastq ~sample_name ?fragment_id how bam =
+  let bam_to_fastq ?fragment_id how bam =
     let input_bam = get_bam bam in
     let sample_type = match how with `SE -> `Single_end | `PE -> `Paired_end in
     let output_prefix =
@@ -666,7 +666,7 @@ module Make (Config : Compiler_configuration)
     in
     Fastq (
       Tools.Picard.bam_to_fastq ~run_with ~sample_type
-        ~sample_name ~output_prefix input_bam
+        ~output_prefix input_bam
     )
 
   let somatic_vc

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -151,13 +151,21 @@ module KEDSL = struct
     is_done: Ketrew_pure.Target.Condition.t option;
     host: Host.t;
     path : string;
+    sample_name: string;
+    escaped_sample_name: string;
     sorting: [ `Coordinate | `Read_name ] option;
     reference_build: string;
   >
-  let bam_file ~host ?sorting ~reference_build path : bam_file =
-    object
+  let bam_file ~host ?name ?sorting ~reference_build path : bam_file =
+    object (self)
       val file = single_file ~host path
       method host = host
+      method sample_name =
+        Option.value name ~default:(Filename.chop_extension (Filename.basename path))
+      method escaped_sample_name =
+        String.map self#sample_name ~f:(function
+          | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' | '-' | '_' as c -> c
+          | other -> '_')
       method path = file#path
       method is_done = file#is_done
       method sorting = sorting


### PR DESCRIPTION
This adds `sample_name` as a property of a BAM similar to fastq instead of carrying around a sample name.

Some of the pipeline aspects were a bit confusing, but this should have the same semantics. Are so many definitions of `bam_to_fastq` needed, seemed to have to edit this in a lot of places?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/305)
<!-- Reviewable:end -->
