### PR TITLE
Add Input.t generation utilities

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -78,6 +78,7 @@ section # Executable tests
     OCamlProgramOfFile(biokepi-test-all-downloads, $(file src/test/all_downloads.ml))
     OCamlProgramOfFile(biokepi-test-ttfi-pipeline, $(file src/test/ttfi_pipeline.ml))
     OCamlProgramOfFile(biokepi-hla-typer, $(file src/app/hla_typer.ml))
+    OCamlProgramOfFile(biokepi-input-generator, $(file src/app/input_gen.ml))
     OCamlProgramOfFile(biokepi-edsl-input-json, $(file src/test/edsl_input_json.ml))
 
 
@@ -88,13 +89,15 @@ install: install-lib-biokepi_run_environment \
          install-lib-biokepi_bfx_tools \
          install-lib-biokepi_pipeline_edsl \
          install-lib-biokepi \
-         install-app-biokepi-demo
+         install-app-biokepi-demo \
+         install-app-biokepi-input-generator
 uninstall: uninstall-lib-biokepi_run_environment \
            uninstall-lib-biokepi_environment_setup \
            uninstall-lib-biokepi_bfx_tools \
            uninstall-lib-biokepi_pipeline_edsl \
            uninstall-lib-biokepi \
-           uninstall-app-biokepi-demo
+           uninstall-app-biokepi-demo \
+           uninstall-app-biokepi-input-generator
 
 # `omake build-all` to build also the tests:
 build-all: lib-biokepi_run_environment \
@@ -103,6 +106,7 @@ build-all: lib-biokepi_run_environment \
            lib-biokepi_pipeline_edsl \
            lib-biokepi \
            app-biokepi-demo \
+           app-biokepi-input-generator \
            app-biokepi-tests app-biokepi-test-all-downloads \
            app-biokepi-hla-typer  app-biokepi-test-ttfi-pipeline \
            app-biokepi-edsl-input-json

--- a/src/app/input_gen.ml
+++ b/src/app/input_gen.ml
@@ -1,0 +1,66 @@
+open Biokepi.EDSL.Library.Input
+open Nonstd
+module String = Sosa.Native_string
+
+let cmd () =
+  let open Cmdliner in
+  let version = "0.0.0" in
+  let doc = "Generate Input.t JSON" in
+  let man = [
+    `S "Description";
+    `P "Given a directory and a host, generate Input.t JSON representing all";
+    `Noblank;
+    `P "the FASTQs found therein.";
+  ] in
+  let name' =
+    let doc = "Name of the dataset; should be unique."
+    in
+    Arg.(required & opt (some string) None & info ["name"; "N"] ~doc)
+  in
+  let host =
+    let doc = "Host where the files are stored, e.g. ssh://dev1,\
+               assuming there is a named SSH host at dev1."
+    in
+    Arg.(required & opt (some string) None & info ["host"; "H"] ~doc)
+  in
+  let fastqs_directory =
+    let doc = "Directory on `host` where tumor fastq.gzs can be found." in
+    Arg.(required & opt (some string) None & info ["directory"; "d"] ~doc)
+  in
+  let single_ended =
+    let doc = "Pass if the reads aren't paired." in
+    Arg.(value & flag & info ["single-ended"] ~doc)
+  in
+  Term.(pure (fun name host directory single_ended ->
+      let host = match Ketrew_pure.Host.of_string host with
+      | `Ok host -> host
+      | `Error msg -> printf "Error parsing host.\n%!"; exit 1
+      in
+      let open Pvem_lwt_unix.Deferred_result in
+      Derive.fastqs ~paired_end:(not single_ended) ~host:host directory
+      >>= fun fqs ->
+      return (fastq_sample ~sample_name:name fqs)
+    ) $ name' $ host $ fastqs_directory $ single_ended),
+  Term.info "Generate Input.t" ~version ~doc ~man
+
+let () =
+  match Cmdliner.Term.eval (cmd ()) with
+  | `Error _ -> exit 1
+  | `Ok r -> begin match Lwt_main.run r with
+    | `Ok fqs ->
+      to_yojson fqs |> Yojson.Safe.pretty_to_channel ~std:true stdout;
+      flush stdout
+    | `Error err ->
+      begin match err with
+      | `Host hosterr ->
+        failwith ("Host could not be used: " ^
+                  (Ketrew.Host_io.Error.log hosterr
+                   |> Ketrew_pure.Internal_pervasives.Log.to_long_string))
+      | `Multiple_flowcells flowcells ->
+        failwith (sprintf "Too many flowcells: '%s'\n%!"
+                    (String.concat ~sep:"," flowcells))
+      | `Re_group_error msg -> failwith msg
+      | `R2_expected_for_r1 r1 -> failwith (sprintf "Didn't find an r2 for r1 %s" r1)
+      end
+    end
+  | `Help | `Version -> exit 0

--- a/src/pipeline_edsl/pipeline_library.mli
+++ b/src/pipeline_edsl/pipeline_library.mli
@@ -13,7 +13,6 @@ module Input : sig
     | PE of string * string
     | SE of string
     | Of_bam of [ `PE | `SE ] * [ `Coordinate | `Read_name ] option * string * string
-  
 
   val pp : Format.formatter -> t -> unit
   val show : t -> string
@@ -33,6 +32,42 @@ module Input : sig
 
   val to_yojson : t -> Yojson.Safe.json
   val of_yojson : Yojson.Safe.json -> (t, string) Pvem.Result.t
+
+  module Derive : sig
+  (** Make it easy to create Input.t from directories on hosts. *)
+    val ensure_one_flowcell_max :
+      string list ->
+      (string list,
+       [> `Multiple_flowcells of string list | `Re_group_error of string ])
+        Pvem_lwt_unix.Deferred_result.t
+    (** This will error out immediately if more than one flowcell is in a directory.
+
+        We want to make sure only one flowcell is in this directory, otherwise
+        this'll give us bad ordering: for now, we'll just fail with an informative
+        exception: if it turns out we need to handle this case, we can do it
+        here. The proper ordering should be grouping and ordering with flowcell
+        groups, and arbitrary order between groups. *)
+
+    val fastqs :
+      ?paired_end:bool ->
+      host:Ketrew_pure.Host.t ->
+      string ->
+      (fastq_fragment list,
+       [> `Host of _ Ketrew.Host_io.Error.execution Ketrew.Host_io.Error.non_zero_execution
+       | `Multiple_flowcells of string list
+       | `R2_expected_for_r1 of string
+       | `Re_group_error of string])
+        Pvem_lwt_unix.Deferred_result.t
+    (** This gives us lexicographically sorted FASTQ filenames in a given directory
+        on the host.
+
+        This assumes Illumina-style file-naming:
+
+        Sample_name_barcode_lane#_read#_fragment#.(flowcell)?.fastq.gz
+
+        N.B. If a given directory contains FASTQs with multiple flowcells, this
+        will fail. *)
+  end
 
 end
 

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -218,11 +218,6 @@ module KEDSL = struct
 
 end
 
-(** and then we forbid any other access to Ketrew, to force everything
-    to throught the above module. *)
-module Ketrew = struct end
-
-
 (** An attempt at standardizing “tags.” *)
 module Target_tags = struct
   let aligner = "aligner"


### PR DESCRIPTION
New executable biokepi-input-generator which takes a host and a dir of
fastq.gz and generates JSON serialization of Input.t for input into
Pipelines.ts.

Library supporting this at Biokepi.EDSL.Library.Input.Derive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/311)
<!-- Reviewable:end -->
