### PR TITLE
Add igvxml

### DIFF
--- a/src/bfx_tools/igvxml.ml
+++ b/src/bfx_tools/igvxml.ml
@@ -1,0 +1,47 @@
+
+open Biokepi_run_environment
+open Common
+
+let vcf ~name ~path = object method name = name method path = path end
+
+let run ~(run_with:Machine.t) ~reference_genome
+    ~normal_bam_path
+    ~tumor_bam_path
+    ~run_id
+    ?rna_bam_path
+    ~vcfs
+    ~output_path
+    () =
+  let open KEDSL in
+  let open Ketrew_pure.Target.Volume in
+  let igvxml = Machine.get_tool run_with Machine.Tool.Default.igvxml in
+  let name = sprintf "Create %s" (Filename.basename output_path) in
+  let make =
+    Machine.quick_run_program run_with
+      ~name
+      ~requirements:[`Self_identification ["igvxml"]]
+      Program.(
+        Machine.Tool.(init igvxml)
+        && exec ["mkdir"; "-p"; (Filename.dirname output_path)]
+        && exec (
+          ["igvxml";
+           "-G"; reference_genome;
+           "--output"; output_path;
+           "-N"; normal_bam_path;
+           "-T"; tumor_bam_path;
+           "--run-id"; run_id;]
+          @ (Option.value_map ~default:[] rna_bam_path ~f:(fun p ->
+              ["-R"; p]))
+          @ ["--vcfs";
+             List.map vcfs ~f:(fun v ->
+                 sprintf "%s=%s" v#name v#path)
+             |> String.concat ~sep:","]
+        )
+      )
+  in
+  workflow_node ~name ~make
+    (single_file output_path ~host:(Machine.as_host run_with))
+    ~edges: [
+      on_failure_activate (Workflow_utilities.Remove.file ~run_with output_path);
+      depends_on (Machine.Tool.ensure igvxml);
+    ]

--- a/src/environment_setup/biopam.ml
+++ b/src/environment_setup/biopam.ml
@@ -308,6 +308,14 @@ let optitype =
             (Opam.bin ~install_path)
       )
 
+let igvxml =
+  install_target
+    ~witness:"igvxml" ~test:test_version
+    ~repository:`Opam
+    ~compiler:"4.02.3"
+    Machine.Tool.Default.igvxml
+
+
 let default :
   run_program: Machine.Make_fun.t ->
   host: Common.KEDSL.Host.t ->
@@ -320,5 +328,6 @@ let default :
     bowtie;
     seq2hla;
     optitype;
+    igvxml;
   ])
 

--- a/src/run_environment/machine.ml
+++ b/src/run_environment/machine.ml
@@ -54,7 +54,9 @@ module Tool = struct
     let optitype = create "optitype" ~version:"1.0.0"
     let seq2hla = create "seq2hla" ~version:"2.2"
     let fastqc = create "fastqc" ~version:"0.11.5"
+    let igvxml = create "igvxml" ~version:"0.0.6"
   end
+
   type t = {
     definition: Definition.t;
     init: Program.t;


### PR DESCRIPTION

This version works only with `b37decoy` and `mm10` (tool's choice).
But it works™ :)

I didn't add to the TTFI EDSL because I don't see the use case.

Also, the results depends on the paths not on the contents of the files at that path (they can run even if they don't exist), so the tool does not depend on the bam/vcf products.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/316)
<!-- Reviewable:end -->
