### PR TITLE
Bwa with pipes

### DIFF
--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -83,6 +83,13 @@ module Generic_optimizer
   let bwa_mem ?configuration ~reference_build fq =
     fwd (Input.bwa_mem ?configuration ~reference_build (bwd fq))
 
+  let bwa_mem_opt ?configuration ~reference_build input =
+    fwd (Input.bwa_mem_opt ?configuration ~reference_build
+           (match input with
+           | `Fastq f -> `Fastq (bwd f)
+           | `Fastq_gz f -> `Fastq_gz (bwd f)
+           | `Bam b -> `Bam (bwd b)))
+
   let star ?configuration ~reference_build fq =
     fwd (Input.star ?configuration ~reference_build (bwd fq))
 

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -88,7 +88,7 @@ module Generic_optimizer
            (match input with
            | `Fastq f -> `Fastq (bwd f)
            | `Fastq_gz f -> `Fastq_gz (bwd f)
-           | `Bam b -> `Bam (bwd b)))
+           | `Bam (b, p) -> `Bam (bwd b, p)))
 
   let star ?configuration ~reference_build fq =
     fwd (Input.star ?configuration ~reference_build (bwd fq))

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -86,7 +86,7 @@ module type Bioinformatics_base = sig
     [
       | `Fastq of [ `Fastq ] repr
       | `Fastq_gz of [ `Gz of [ `Fastq ] ] repr
-      | `Bam of [ `Bam ] repr
+      | `Bam of [ `Bam ] repr * [ `PE | `SE ]
     ] ->
     [ `Bam ] repr
 

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -79,6 +79,17 @@ module type Bioinformatics_base = sig
     [ `Fastq ] repr ->
     [ `Bam ] repr
 
+  (** Optimized version of bwa-mem. *)
+  val bwa_mem_opt:
+    ?configuration: Biokepi_bfx_tools.Bwa.Configuration.Mem.t ->
+    reference_build: Biokepi_run_environment.Reference_genome.name ->
+    [
+      | `Fastq of [ `Fastq ] repr
+      | `Fastq_gz of [ `Gz of [ `Fastq ] ] repr
+      | `Bam of [ `Bam ] repr
+    ] ->
+    [ `Bam ] repr
+
   val star:
     ?configuration: Star.Configuration.Align.t ->
     reference_build: Biokepi_run_environment.Reference_genome.name ->

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -125,6 +125,22 @@ module Make_serializer (How : sig
       ?(configuration = Tools.Bwa.Configuration.Mem.default) =
     aligner "bwa-mem" (Tools.Bwa.Configuration.Mem.name configuration)
 
+  let bwa_mem_opt
+      ?(configuration = Tools.Bwa.Configuration.Mem.default)
+      ~reference_build
+      input =
+    match input with
+    | `Fastq f ->
+      aligner "bwa-mem-opt-fq" (Tools.Bwa.Configuration.Mem.name configuration)
+        ~reference_build f
+    | `Fastq_gz f ->
+      aligner "bwa-mem-opt-fqz" (Tools.Bwa.Configuration.Mem.name configuration)
+        ~reference_build f
+    | `Bam (f, _) ->
+      aligner "bwa-mem-opt-bam" (Tools.Bwa.Configuration.Mem.name configuration)
+        ~reference_build f
+
+
   let gunzip gz ~(var_count : int) =
     function_call "gunzip" ["input", gz ~var_count]
 


### PR DESCRIPTION
Cf. #29.

I've tested the `Tools.Bwa.mem_align_to_bam` function but not yet the TTFI
version.

Instead of augmenting the current `bwa_mem` it is added as a new one:

```ocaml
  val bwa_mem_opt:
    ?configuration: Biokepi_bfx_tools.Bwa.Configuration.Mem.t ->
    reference_build: Biokepi_run_environment.Reference_genome.name ->
    [
      | `Fastq of [ `Fastq ] repr
      | `Fastq_gz of [ `Gz of [ `Fastq ] ] repr
      | `Bam of [ `Bam ] repr * [ `PE | `SE ]
    ] ->
    [ `Bam ] repr
```


In branch:
[`covariant-ttfi-repr`](https://github.com/hammerlab/biokepi/tree/covariant-ttfi-repr/)
there is an in-progress version of:

```ocaml
  val bwa_mem:
    ?configuration: Biokepi_bfx_tools.Bwa.Configuration.Mem.t ->
    reference_build: Biokepi_run_environment.Reference_genome.name ->
    [ `Fastq | `Gz of [ `Fastq ] | `Bam ] repr ->
    [ `Bam ] repr
```

but this does not work because `'a repr` is not covariant.

The branch tries to make it covariant; but fails with the Optimization-framework
[GADT](https://github.com/hammerlab/biokepi/blob/covariant-ttfi-repr/src/pipeline_edsl/transform_applications.ml#L33)
(variance of GADTs, not an easy thing:
<https://www.mail-archive.com/caml-list@inria.fr/msg01804.html>).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/318)
<!-- Reviewable:end -->
