### PR TITLE
Add samblaster tool

### DIFF
--- a/src/environment_setup/tool_providers.ml
+++ b/src/environment_setup/tool_providers.ml
@@ -414,6 +414,16 @@ let fastqc =
     ~init_program
     ~unarchived_directory:"FastQC"
 
+  let samblaster = 
+    let binary = "samblaster" in
+    installable_tool
+      Machine.Tool.Default.samblaster
+      ~url:"https://github.com/GregoryFaust/samblaster/releases/download/v.0.1.22/samblaster-v.0.1.22.tar.gz"
+      ~install_program:(make_and_copy_bin binary)
+      ~init_program:add_to_dollar_path
+      ~witness:(witness_file binary)
+
+
 let default_jar_location msg (): broad_jar_location =
   `Fail (sprintf "No location provided for %s" msg)
 
@@ -448,6 +458,7 @@ let default_toolkit
       install mosaik;
       install kallisto;
       install fastqc;
+      install samblaster;
     ];
     Biopam.default ~run_program ~host
       ~install_path:(install_tools_path // "biopam-kit") ();

--- a/src/run_environment/machine.ml
+++ b/src/run_environment/machine.ml
@@ -56,6 +56,7 @@ module Tool = struct
     let fastqc = create "fastqc" ~version:"0.11.5"
     let igvxml = create "igvxml" ~version:"0.0.6"
     let hlarp = create "hlarp" ~version:"biokepi-branch"
+    let samblaster = create "samblaster" ~version:"v.0.1.22"
   end
 
   type t = {


### PR DESCRIPTION
This adds [samblaster](https://github.com/GregoryFaust/samblaster) as an installable tool

Why?
- In `bwa_mem_opt` I can add this to the command:
```
       command_to_stdout; "|";
+      "samblaster"; "|";
       "samtools"; "view"; "-b"; "|";
```
- it is used for marking duplicates in [bwakit](https://github.com/lh3/bwa/tree/master/bwakit) as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/341)
<!-- Reviewable:end -->
