### PR TITLE
NetMHC: support for installing netmhc 3.4

### DIFF
--- a/src/run_environment/workflow_utilities.ml
+++ b/src/run_environment/workflow_utilities.ml
@@ -221,7 +221,7 @@ module Download = struct
       let is_bzip = Filename.check_suffix url ".bz2" in
       if is_gz then "z" else if is_bzip then "j" else ""
     in
-    let tar_filename = (destination_folder ^ ".tar") in
+    let tar_filename = (destination_folder // "archive.tar") in
     let name = "untar-" ^ tar_filename in
     let wgot = wget ~host ~run_program url tar_filename in
     let file_in_tar = (destination_folder // tar_contains) in


### PR DESCRIPTION
As @tavinathanson pointed out, the official documentation for the `NetMHCcons` suggest using `NetMHC 3.4` and not the `4.0`. The installation of the former requires special treatment and some more customization to the procedure, so this PR follows up on #344 and adds support for installing `netMHC 3.4`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/347)
<!-- Reviewable:end -->
