### PR TITLE
Better tame the NetMHC tool installations

### DIFF
--- a/src/environment_setup/conda.ml
+++ b/src/environment_setup/conda.ml
@@ -115,8 +115,12 @@ let configured ~conda_env ~(run_program : Machine.Make_fun.t) ~host =
 
 
 let init_env ~conda_env () =
+  let prefix = (envs_dir ~conda_env // conda_env.name) in
+  (* if we are already within the conda environment we want, do nothing;
+     otherwise, activate the new one *)
   KEDSL.Program.(
-    shf "source %s %s"
+    shf "[ ${CONDA_PREFIX-none} != \"%s\" ] && source %s %s"
+      prefix
       (activate ~conda_env)
-      (envs_dir ~conda_env // conda_env.name)
+      prefix
   )

--- a/src/environment_setup/conda.ml
+++ b/src/environment_setup/conda.ml
@@ -119,8 +119,8 @@ let init_env ~conda_env () =
   (* if we are already within the conda environment we want, do nothing;
      otherwise, activate the new one *)
   KEDSL.Program.(
-    shf "[ ${CONDA_PREFIX-none} != \"%s\" ] && source %s %s"
-      prefix
-      (activate ~conda_env)
-      prefix
+    shf "[ ${CONDA_PREFIX-none} != \"%s\" ] \
+         && source %s %s \
+         || echo 'Already in conda env: %s'"
+      prefix (activate ~conda_env) prefix prefix
   )

--- a/src/environment_setup/netmhc.ml
+++ b/src/environment_setup/netmhc.ml
@@ -189,7 +189,8 @@ let default_netmhc_install
           shf "tar zxf %s" downloaded_file#product#path &&
           shf "cd %s" tool_path &&
           chain (List.map ~f:fix_script env_setup) &&
-          shf "chmod +x %s" binary_path
+          shf "chmod +x %s" binary_path &&
+          shf "mkdir -p %s" (tmp_dir install_path)
         )
       )
   in

--- a/src/environment_setup/netmhc.ml
+++ b/src/environment_setup/netmhc.ml
@@ -1,6 +1,8 @@
 open Biokepi_run_environment
 open Common
 
+let rm_path = Workflow_utilities.Remove.path_on_host
+
 (* 
   Tested against:
 
@@ -176,7 +178,8 @@ let default_netmhc_install
       ~name:("Install NetMHC tool: " ^ tool_name)
       ~edges:(
         [ depends_on downloaded_file; 
-          depends_on Conda.(configured ~run_program ~host ~conda_env) ]
+          depends_on Conda.(configured ~run_program ~host ~conda_env);
+          on_failure_activate (rm_path ~host install_path); ]
         @ (if with_data then [ depends_on downloaded_data_file; ] else [])
         @ (List.map depends ~f:(fun d -> depends_on d))
       )


### PR DESCRIPTION
follow-up to #287, #347, and #351 to fix various issues with the latest setup:

- Installs a clean Python 2 environment to be used by NetMHC tools (so that no other Python installation interferes with their function)
  - Also fixes the old NetMHC script to force it use whatever Python is available in the `$PATH`
- Improves `Conda`'s init function in such a way that if the environment is already active, it won't get activated once more (provides smooth handling of env variables if one is to init multiple netMHC tools independently)
- Now cleans up after itself on failure
- Creates the `$TMPDIR` beforehand to satisfy `NetMHC`'s weak assumptions

All of these tested on a clean VM on Gcloud, so this should be good to go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/353)
<!-- Reviewable:end -->
