### PR TITLE
NetMHC: wrap the netMHC wrappers for better environment control

### DIFF
--- a/src/environment_setup/conda.ml
+++ b/src/environment_setup/conda.ml
@@ -44,6 +44,7 @@ let envs_dir ~conda_env = conda_env.install_path // conda_env.envs_subdir
 let commands ~conda_env com = main_dir ~conda_env // "bin" // com
 let bin ~conda_env = commands ~conda_env "conda"
 let activate ~conda_env = commands ~conda_env "activate"
+let deactivate ~conda_env = commands ~conda_env "deactivate"
 let environment_path ~conda_env = envs_dir ~conda_env // conda_env.name
 
 (* give a conda command. *)
@@ -123,4 +124,13 @@ let init_env ~conda_env () =
          && source %s %s \
          || echo 'Already in conda env: %s'"
       prefix (activate ~conda_env) prefix prefix
+  )
+
+let deactivate_env ~conda_env () =
+  let prefix = (envs_dir ~conda_env // conda_env.name) in
+  KEDSL.Program.(
+    shf "[ ${CONDA_PREFIX-none} == \"%s\" ] \
+         && source %s \
+         || echo 'Doing nothing. The conda env is not active: %s'"
+      prefix (deactivate ~conda_env) prefix
   )

--- a/src/environment_setup/conda.mli
+++ b/src/environment_setup/conda.mli
@@ -41,6 +41,12 @@ val init_env :
   unit -> 
   Common.KEDSL.Program.t
 
+(** A transform to deactivate the conda environment if it is already active *)
+val deactivate_env : 
+  conda_env: conda_environment_type -> 
+  unit -> 
+  Common.KEDSL.Program.t
+
 (** This is the absolute path to the environment folder **)
 val environment_path : 
   conda_env: conda_environment_type -> 

--- a/src/environment_setup/netmhc.ml
+++ b/src/environment_setup/netmhc.ml
@@ -174,8 +174,8 @@ let create_netmhc_runner_cmd
   let cmd = 
     sprintf
       "cat << EOF > %s\
-       %s
-       EOF
+       %s\
+       EOF\
       "
       dest
       script_contents

--- a/src/environment_setup/netmhc.ml
+++ b/src/environment_setup/netmhc.ml
@@ -148,24 +148,20 @@ let netmhc_conda_env install_path =
 let netmhc_runner_path install_path = install_path // "biokepi_runner"
 
 let netmhc_runner_script_contents ~binary_name ~binary_path ~conda_env =
-  let open Ketrew_pure in
-  let open Program in
-  let open Internal_pervasives in
-  let activate = Conda.init_env ~conda_env () in
-  let deactivate = Conda.deactivate_env ~conda_env () in
-  fmt {bash|
+  Ketrew_pure.Internal_pervasives.fmt {bash|
 #!/bin/bash
 
-# Activate the conda environment
-%s
+# Force use the controlled python environment
+OLD_PATH=$PATH
+export PATH=%s:$PATH
+
 # Run the netMHC* binary
 %s "$@"
-# Deactivate the conda environment
-%s
+
+export PATH=$OLD_PATH
 |bash}
-    (to_single_shell_command activate)
+    Conda.((environment_path ~conda_env) // "bin")
     binary_path
-    (to_single_shell_command deactivate)
 
 let create_netmhc_runner_cmd
     ~binary_name ~binary_path ~conda_env dest =


### PR DESCRIPTION
so that when another tool (e.g. vaxrank) that depends on another version of Python (e.g. v3) calls one of these scripts, we make sure that we first enter into the environment we set up (Python v2), run the tool and go back to the whatever environment we had :man::gun:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/biokepi/355)
<!-- Reviewable:end -->
