### PR TITLE
Implement vcf product

### DIFF
--- a/src/bfx_tools/bedtools.ml
+++ b/src/bfx_tools/bedtools.ml
@@ -110,7 +110,6 @@ let intersect
     depends_on Machine.Tool.(ensure bedtools);
     on_failure_activate (Remove.file run_with output)
   ] @ (List.map ~f:depends_on intersect_with) in
-  let host = Machine.as_host run_with in
-  let out = single_file ~host output in
+  let out = transform_vcf primary#product ~path:output in
   workflow_node out ~name ~edges ~make
-    ~ensures:(`Is_verified (out#is_bigger_than 1))
+    ~ensures:(`Is_verified (out#as_single_file#is_bigger_than 1))

--- a/src/bfx_tools/gatk.ml
+++ b/src/bfx_tools/gatk.ml
@@ -540,7 +540,8 @@ let haplotype_caller
           )
       in
       workflow_node ~name ~make
-        (single_file output_vcf ~host:Machine.(as_host run_with))
+        (vcf_file output_vcf ~reference_build:input_bam#product#reference_build
+           ~host:Machine.(as_host run_with))
         ~tags:[Target_tags.variant_caller]
         ~edges:(add_edges @ [
             depends_on Machine.Tool.(ensure gatk);
@@ -618,7 +619,9 @@ let mutect2
           )
       in
       workflow_node ~name ~make
-        (single_file output_vcf ~host:Machine.(as_host run_with))
+        (vcf_file output_vcf
+           ~reference_build:input_normal_bam#product#reference_build
+           ~host:Machine.(as_host run_with))
         ~tags:[Target_tags.variant_caller]
         ~edges:(add_edges @ confg_edges @ [
             depends_on Machine.Tool.(ensure gatk);

--- a/src/bfx_tools/muse.ml
+++ b/src/bfx_tools/muse.ml
@@ -77,7 +77,9 @@ let run
           )
       in
       workflow_node ~name ~make
-        (single_file output_file ~host:Machine.(as_host run_with))
+        (vcf_file output_file
+           ~reference_build:normal#product#reference_build
+           ~host:Machine.(as_host run_with))
         ~tags:[Target_tags.variant_caller; "muse"]
         ~edges:[
           depends_on Machine.Tool.(ensure muse_tool);
@@ -113,16 +115,18 @@ let run
         )
     in
     workflow_node ~name ~make
-      (single_file vcf_output ~host:Machine.(as_host run_with))
+      (vcf_file vcf_output
+         ~reference_build:normal#product#reference_build
+         ~host:Machine.(as_host run_with))
       ~tags:[Target_tags.variant_caller; "muse"]
       ~edges:(more_edges @ [ (* muse_sump is the last step in every case *)
-        depends_on Machine.Tool.(ensure muse_tool);
-        depends_on call_file;
-        depends_on bgzipped_dbsnp;
-        depends_on
-          (Samtools.tabix ~run_with ~tabular_format:`Vcf bgzipped_dbsnp);
-        on_failure_activate (Remove.file ~run_with vcf_output);
-      ])
+          depends_on Machine.Tool.(ensure muse_tool);
+          depends_on call_file;
+          depends_on bgzipped_dbsnp;
+          depends_on
+            (Samtools.tabix ~run_with ~tabular_format:`Vcf bgzipped_dbsnp);
+          on_failure_activate (Remove.file ~run_with vcf_output);
+        ])
   in
   begin match how with
   | `Region region ->

--- a/src/bfx_tools/mutect.ml
+++ b/src/bfx_tools/mutect.ml
@@ -109,7 +109,9 @@ let run
           on_failure_activate (Remove.file ~run_with output_file);
         ] in
       workflow_node ~name ~make
-        (single_file output_file ~host:Machine.(as_host run_with))
+        (vcf_file output_file
+           ~reference_build:normal#product#reference_build
+           ~host:Machine.(as_host run_with))
         ~tags:[Target_tags.variant_caller] ~edges
     in
     run_mutect

--- a/src/bfx_tools/somaticsniper.ml
+++ b/src/bfx_tools/somaticsniper.ml
@@ -37,7 +37,7 @@ end
 
 let run
     ~run_with
-     ?(configuration = Configuration.default) ~normal ~tumor ~result_prefix () =
+    ?(configuration = Configuration.default) ~normal ~tumor ~result_prefix () =
   let open KEDSL in
   let result_file suffix = sprintf "%s-%s" result_prefix suffix in
   let name = sprintf "somaticsniper: %s" (result_file "") in
@@ -68,7 +68,9 @@ let run
           ))
   in
   workflow_node ~name ~make
-    (single_file output_file ~host:Machine.(as_host run_with))
+    (vcf_file output_file
+       ~reference_build:normal#product#reference_build
+       ~host:Machine.(as_host run_with))
     ~metadata:(`String name)
     ~tags:[Target_tags.variant_caller; "somaticsniper"]
     ~edges:[

--- a/src/bfx_tools/strelka.ml
+++ b/src/bfx_tools/strelka.ml
@@ -176,17 +176,19 @@ let run
       )
   in
   workflow_node ~name ~make
-    (single_file output_file_path ~host:(Machine.as_host run_with))
+    (vcf_file output_file_path
+       ~reference_build:normal#product#reference_build
+       ~host:Machine.(as_host run_with))
     ~edges:(more_edges @ [
-      depends_on normal;
-      depends_on tumor;
-      depends_on reference_fasta;
-      depends_on (Machine.Tool.ensure strelka_tool);
-      depends_on (Machine.Tool.ensure gatk_tool);
-      depends_on sorted_normal;
-      depends_on sorted_tumor;
-      depends_on (Picard.create_dict ~run_with reference_fasta);
-      depends_on (Samtools.faidx ~run_with reference_fasta);
-      depends_on (Samtools.index_to_bai ~run_with sorted_normal);
-      depends_on (Samtools.index_to_bai ~run_with sorted_tumor);
-    ])
+        depends_on normal;
+        depends_on tumor;
+        depends_on reference_fasta;
+        depends_on (Machine.Tool.ensure strelka_tool);
+        depends_on (Machine.Tool.ensure gatk_tool);
+        depends_on sorted_normal;
+        depends_on sorted_tumor;
+        depends_on (Picard.create_dict ~run_with reference_fasta);
+        depends_on (Samtools.faidx ~run_with reference_fasta);
+        depends_on (Samtools.index_to_bai ~run_with sorted_normal);
+        depends_on (Samtools.index_to_bai ~run_with sorted_tumor);
+      ])

--- a/src/bfx_tools/varscan.ml
+++ b/src/bfx_tools/varscan.ml
@@ -95,8 +95,9 @@ let somatic_on_region
       |> Machine.run_big_program run_with ~name ~processors:1
         ~self_ids:["varscan"; "somaticfilter"]
     in
-    workflow_node ~name
-      (single_file snp_filtered ~host) ~make ~tags
+    workflow_node ~name ~make ~tags
+      (vcf_file snp_filtered
+         ~reference_build:normal#product#reference_build ~host)
       ~edges:[
         depends_on varscan_somatic;
         on_failure_activate (Remove.file ~run_with snp_filtered);

--- a/src/bfx_tools/vcfannotatepolyphen.ml
+++ b/src/bfx_tools/vcfannotatepolyphen.ml
@@ -4,8 +4,8 @@ open Common
 let run ~(run_with: Machine.t) ~reference_build ~vcf ~output_vcf =
   let open KEDSL in
   let vap_tool =
-    Machine.get_tool run_with Machine.Tool.Definition.(create "vcf-annotate-polyphen")
-  in
+    Machine.get_tool run_with
+      Machine.Tool.Definition.(create "vcf-annotate-polyphen") in
   let whessdb = Machine.(get_reference_genome run_with reference_build)
     |> Reference_genome.whess_exn
   in
@@ -13,7 +13,7 @@ let run ~(run_with: Machine.t) ~reference_build ~vcf ~output_vcf =
   let vcf_path = vcf#product#path in
   let name = sprintf "vcf-annotate-polyphen_%s" (Filename.basename vcf_path) in
   workflow_node
-    (single_file output_vcf ~host:Machine.(as_host run_with))
+    (transform_vcf vcf#product ~path:output_vcf)
     ~name
     ~edges:[
       depends_on Machine.Tool.(ensure vap_tool);

--- a/src/bfx_tools/vcftools.ml
+++ b/src/bfx_tools/vcftools.ml
@@ -15,5 +15,10 @@ let vcf_concat ~(run_with:Machine.t) ?more_edges vcfs ~final_vcf =
   let vcftools = Machine.get_tool run_with Machine.Tool.Default.vcftools in
   let host = Machine.(as_host run_with) in
   let run_program = Machine.run_program run_with in
+  let reference_build =
+    Option.value_exn (List.hd vcfs)
+      ~msg:"Vcftools.vcf_concat: empty vcf list!"
+    |> fun v -> v#product#reference_build in
   Workflow_utilities.Vcftools.vcf_concat_no_machine
+    ~make_product:(fun p -> KEDSL.vcf_file p ~host ~reference_build)
     ~host ~vcftools ~run_program ?more_edges vcfs ~final_vcf

--- a/src/bfx_tools/virmid.ml
+++ b/src/bfx_tools/virmid.ml
@@ -76,7 +76,9 @@ let run
       )
   in
   workflow_node ~name ~make
-    (single_file output_file ~host:(Machine.as_host run_with))
+    (vcf_file output_file
+       ~reference_build:normal#product#reference_build
+       ~host:Machine.(as_host run_with))
     ~edges:(more_edges @ [
         depends_on normal;
         depends_on tumor;

--- a/src/environment_setup/download_reference_genomes.ml
+++ b/src/environment_setup/download_reference_genomes.ml
@@ -44,10 +44,12 @@ let of_specification
         let tmp_vcf =
           dest_file (Filename.chop_extension filename ^ "-cat.vcf") in
         Vcftools.vcf_concat_no_machine
+          ~make_product:(fun p -> KEDSL.single_file p ~host)
           ~host ~vcftools ~run_program ~final_vcf:tmp_vcf vcfs in
       let sorted =
         let final_vcf_path = dest_file filename in
         Vcftools.vcf_sort_no_machine
+          ~make_product:(fun p -> KEDSL.single_file p ~host)
           ~host ~vcftools ~run_program
           ~src:concated ~dest:final_vcf_path () in
       sorted

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -180,15 +180,14 @@ module Generic_optimizer
   let flagstat bam =
     fwd (Input.flagstat (bwd bam))
 
-  let vcf_annotate_polyphen reference_build vcf =
-    fwd (Input.vcf_annotate_polyphen reference_build (bwd vcf))
-  let isovar ?configuration reference_build vcf bam =
-    fwd (Input.isovar ?configuration reference_build (bwd vcf) (bwd bam))
-  let topiary ?configuration reference_build vcf predictor alleles = 
-    fwd (Input.topiary
-           ?configuration reference_build (bwd vcf) predictor (bwd alleles))
-  let vaxrank ?configuration reference_build vcfs bam predictor alleles =
-    fwd (Input.vaxrank ?configuration reference_build
+  let vcf_annotate_polyphen vcf =
+    fwd (Input.vcf_annotate_polyphen (bwd vcf))
+  let isovar ?configuration vcf bam =
+    fwd (Input.isovar ?configuration (bwd vcf) (bwd bam))
+  let topiary ?configuration vcf predictor alleles = 
+    fwd (Input.topiary ?configuration (bwd vcf) predictor (bwd alleles))
+  let vaxrank ?configuration vcfs bam predictor alleles =
+    fwd (Input.vaxrank ?configuration
            (List.map ~f:(fun v -> (bwd v)) vcfs)
            (bwd bam) predictor (bwd alleles))
 end

--- a/src/pipeline_edsl/pipeline.ml
+++ b/src/pipeline_edsl/pipeline.ml
@@ -63,7 +63,7 @@ module Variant_caller = struct
       result_prefix: string ->
       ?more_edges: KEDSL.workflow_edge list ->
       unit ->
-      KEDSL.file_workflow
+      KEDSL.vcf_file KEDSL.workflow_node
   }
 end
 
@@ -527,8 +527,8 @@ module Compiler = struct
       KEDSL.bam_file KEDSL.workflow_node;
     wrap_vcf_node:
       vcf pipeline ->
-      KEDSL.single_file KEDSL.workflow_node ->
-      KEDSL.single_file KEDSL.workflow_node;
+      KEDSL.vcf_file KEDSL.workflow_node ->
+      KEDSL.vcf_file KEDSL.workflow_node;
     wrap_gtf_node:
       gtf pipeline ->
       KEDSL.single_file KEDSL.workflow_node ->

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -231,20 +231,17 @@ module type Bioinformatics_base = sig
   val flagstat: [ `Bam ] repr -> [ `Flagstat ] repr
 
   val vcf_annotate_polyphen:
-    Biokepi_run_environment.Reference_genome.name ->
     [ `Vcf ] repr ->
     [ `Vcf ] repr
 
   val isovar:
     ?configuration: Isovar.Configuration.t ->
-    Biokepi_run_environment.Reference_genome.name ->
     [ `Vcf ] repr ->
     [ `Bam ] repr ->
     [ `Isovar ] repr
 
   val topiary:
     ?configuration: Topiary.Configuration.t ->
-    Biokepi_run_environment.Reference_genome.name ->
     [ `Vcf ] repr ->
     Topiary.predictor_type ->
     [ `MHC_alleles ] repr ->
@@ -252,7 +249,6 @@ module type Bioinformatics_base = sig
 
   val vaxrank:
     ?configuration: Vaxrank.Configuration.t ->
-    Biokepi_run_environment.Reference_genome.name ->
     [ `Vcf ] repr list ->
     [ `Bam ] repr ->
     Topiary.predictor_type ->

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -236,36 +236,41 @@ module Make_serializer (How : sig
   let flagstat =
     one_to_one "flagstat" "default"
 
-  let vcf_annotate_polyphen reference_build =
+  let vcf_annotate_polyphen =
     one_to_one "vcf_annotate_polyphen" "default"
 
   let isovar
-      ?(configuration = Tools.Isovar.Configuration.default) reference_build vcf =
-    one_to_one "isovar" Tools.Isovar.Configuration.(name configuration)
+      ?(configuration = Tools.Isovar.Configuration.default) vcf bam =
+    fun ~(var_count : int) ->
+      let vcf_compiled = vcf ~var_count in
+      let bam_compiled = bam ~var_count in
+      function_call "isovar" [
+        "configuration", string Tools.Isovar.Configuration.(name configuration);
+        "vcf", vcf_compiled;
+        "bam", bam_compiled;
+      ]
 
   let topiary
-    ?(configuration = Tools.Topiary.Configuration.default)
-    reference_build vcf predictor alleles =
+      ?(configuration = Tools.Topiary.Configuration.default)
+      vcf predictor alleles =
     fun ~(var_count : int) ->
       let vcf_compiled = vcf ~var_count in
       function_call "topiary" [
         "configuration", string Tools.Topiary.Configuration.(name configuration);
         "alleles", alleles ~var_count;
-        "reference_build", string reference_build;
         "predictor", string Tools.Topiary.(predictor_to_string predictor);
         "vcf", vcf_compiled;
       ]
 
   let vaxrank
     ?(configuration = Tools.Vaxrank.Configuration.default)
-    reference_build vcfs bam predictor alleles =
+    vcfs bam predictor alleles =
     fun ~(var_count : int) ->
       let vcfs_compiled = List.map vcfs ~f:(fun v -> v ~var_count) in
       let bam_compiled = bam ~var_count in
       function_call "vaxrank" ([
         "configuration", string Tools.Vaxrank.Configuration.(name configuration);
         "alleles", alleles ~var_count;
-        "reference_build", string reference_build;
         "predictor", string Tools.Topiary.(predictor_to_string predictor);
         "bam", bam_compiled;
       ] @ (List.mapi ~f:(fun i v -> (sprintf "vcf%d" i, v)) vcfs_compiled))

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -13,7 +13,7 @@ module File_type_specification = struct
     | To_unit: 'a t -> unit t
     | Fastq: fastq_reads workflow_node -> [ `Fastq ] t
     | Bam: bam_file workflow_node -> [ `Bam ] t
-    | Vcf: single_file workflow_node -> [ `Vcf ] t
+    | Vcf: vcf_file workflow_node -> [ `Vcf ] t
     | Bed: single_file workflow_node -> [ `Bed ] t
     | Gtf: single_file workflow_node -> [ `Gtf ] t
     | Seq2hla_result:
@@ -71,7 +71,7 @@ module File_type_specification = struct
   | Bam b -> b
   | o -> fail_get o "Bam"
 
-  let get_vcf : [ `Vcf ] t -> single_file workflow_node = function
+  let get_vcf : [ `Vcf ] t -> vcf_file workflow_node = function
   | Vcf v -> v
   | o -> fail_get o "Vcf"
 

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -691,18 +691,27 @@ module Make (Config : Compiler_configuration)
     let bam = get_bam bam in
     Flagstat_result (Tools.Samtools.flagstat ~run_with bam)
 
-  let vcf_annotate_polyphen reference_build vcf =
+  let vcf_annotate_polyphen vcf =
     let v = get_vcf vcf in
     let output_vcf = (Filename.chop_extension v#product#path) ^ "_polyphen.vcf" in
+    let reference_build = v#product#reference_build in
     Vcf (
       Tools.Vcfannotatepolyphen.run ~run_with ~reference_build ~vcf:v ~output_vcf
     )
 
   let isovar
       ?(configuration=Tools.Isovar.Configuration.default)
-      reference_build vcf bam =
+      vcf bam =
     let v = get_vcf vcf in
     let b = get_bam bam in
+    let reference_build =
+      if v#product#reference_build = b#product#reference_build
+      then v#product#reference_build
+      else
+        ksprintf failwith "VCF and Bam do not agree on their reference build: \
+                           bam: %s Vs vcf: %s"
+          b#product#reference_build v#product#reference_build
+    in
     let output_file =
       Name_file.in_directory ~readable_suffix:"isovar.csv" Config.work_dir [
         Tools.Isovar.Configuration.name configuration;
@@ -716,8 +725,9 @@ module Make (Config : Compiler_configuration)
     )
 
   let topiary ?(configuration=Tools.Topiary.Configuration.default)
-      reference_build vcf predictor alleles =
+      vcf predictor alleles =
     let v = get_vcf vcf in
+    let reference_build = v#product#reference_build in
     let mhc = get_mhc_alleles alleles in
     let output_file =
       Name_file.from_path v#product#path ~readable_suffix:"topiary.csv" [
@@ -735,9 +745,21 @@ module Make (Config : Compiler_configuration)
 
   let vaxrank
       ?(configuration=Tools.Vaxrank.Configuration.default)
-      reference_build vcfs bam predictor alleles =
+      vcfs bam predictor alleles =
     let vcfs = List.map ~f:get_vcf vcfs in
     let b = get_bam bam in
+    let reference_build =
+      if List.exists vcfs ~f:(fun v ->
+          v#product#reference_build <> b#product#reference_build)
+      then
+        ksprintf failwith "VCFs and Bam do not agree on their reference build: \
+                           bam: %s Vs vcfs: %s"
+          b#product#reference_build
+          (List.map vcfs ~f:(fun v -> v#product#reference_build)
+           |> String.concat ~sep:", ")
+      else
+        b#product#reference_build
+    in
     let mhc = get_mhc_alleles alleles in
     let outdir =
       Name_file.in_directory ~readable_suffix:"vaxrank" Config.work_dir

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -295,6 +295,25 @@ module KEDSL = struct
     | Single_bam: bam_file workflow_node -> bam_file workflow_node bam_or_bams
     | Bam_workflow_list: bam_file workflow_node list -> bam_list workflow_node bam_or_bams
 
+  type vcf_file = <
+    is_done: Ketrew_pure.Target.Condition.t option;
+    host: Host.t;
+    path : string;
+    reference_build: string;
+    as_single_file: single_file product;
+  >
+  let vcf_file ~host ~reference_build path : vcf_file =
+    object (self)
+      val file = single_file ~host path
+      method host = host
+      method path = file#path
+      method is_done = file#is_done
+      method reference_build = reference_build
+      method as_single_file = file
+    end
+  let transform_vcf vcf ~path =
+    vcf_file ~host:vcf#host ~reference_build:vcf#reference_build vcf#path
+
   let submit w = Ketrew.Client.submit_workflow w
 
 end

--- a/src/run_environment/common.ml
+++ b/src/run_environment/common.ml
@@ -312,7 +312,7 @@ module KEDSL = struct
       method as_single_file = file
     end
   let transform_vcf vcf ~path =
-    vcf_file ~host:vcf#host ~reference_build:vcf#reference_build vcf#path
+    vcf_file ~host:vcf#host ~reference_build:vcf#reference_build path
 
   let submit w = Ketrew.Client.submit_workflow w
 

--- a/src/run_environment/workflow_utilities.ml
+++ b/src/run_environment/workflow_utilities.ml
@@ -299,6 +299,7 @@ module Vcftools = struct
       ~(run_program : Machine.Make_fun.t)
       ?(more_edges = [])
       ~vcfs
+      ~make_product
       ~final_vcf
       command_prefix
     =
@@ -315,7 +316,7 @@ module Vcftools = struct
             final_vcf
         ) in
     workflow_node ~name
-      (single_file final_vcf ~host)
+      (make_product final_vcf)
       ~make
       ~edges:(
         on_failure_activate
@@ -335,9 +336,11 @@ module Vcftools = struct
       ~vcftools
       ~(run_program : Machine.Make_fun.t)
       ?more_edges
+      ~make_product
       vcfs
       ~final_vcf =
     vcf_process_n_to_1_no_machine
+      ~make_product
       ~host ~vcftools ~run_program ?more_edges ~vcfs ~final_vcf
       "vcf-concat"
 
@@ -353,10 +356,12 @@ module Vcftools = struct
       ~vcftools
       ~(run_program : Machine.Make_fun.t)
       ?more_edges
+      ~make_product
       ~src ~dest () =
     let run_program =
       Machine.Make_fun.with_requirements run_program [`Memory `Big] in 
     vcf_process_n_to_1_no_machine
+      ~make_product:(fun p -> KEDSL.single_file p ~host)
       ~host ~vcftools ~run_program ?more_edges ~vcfs:[src] ~final_vcf:dest
       "vcf-sort -c"
 

--- a/src/run_environment/workflow_utilities.ml
+++ b/src/run_environment/workflow_utilities.ml
@@ -361,7 +361,7 @@ module Vcftools = struct
     let run_program =
       Machine.Make_fun.with_requirements run_program [`Memory `Big] in 
     vcf_process_n_to_1_no_machine
-      ~make_product:(fun p -> KEDSL.single_file p ~host)
+      ~make_product
       ~host ~vcftools ~run_program ?more_edges ~vcfs:[src] ~final_vcf:dest
       "vcf-sort -c"
 


### PR DESCRIPTION
As we discussed once, there is now a `vcf_file` ketrew-product.

This makes some `reference_build` arguments redundant/useless in the EDSL, so the API-breaking change is that simplification (minor PR to epidisco on the way).

While propagating I fixed a minor bug in `isovar`'s `To_json`/`To_display`.

I also added a couple more "conformity checks" (that VCFs and Bams have the same reference-build).