### PR TITLE
Properly name the outputs of Bedtools intersect

### DIFF
--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -692,7 +692,7 @@ module Make (Config : Compiler_configuration)
     let vcf = get_vcf vcf in
     let bed = get_bed bed in
     let output =
-      Name_file.from_path bed#product#path ~readable_suffix:"_intersect.vcf"
+      Name_file.from_path vcf#product#path ~readable_suffix:"_intersect.vcf"
         [Filename.basename bed#product#path |> Filename.chop_extension]
     in
     Vcf (Tools.Bedtools.intersect


### PR DESCRIPTION
The EDSL was collapsing the names of bedtools intersected products.