### PR TITLE
fix OptiType installation and init procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ os:
 - osx
 sudo: true
 env:
-  - OCAML_VERSION=4.02.3 OPAM_VERSION=1.2.1
   - OCAML_VERSION=4.03.0 OPAM_VERSION=1.2.1

--- a/src/environment_setup/biopam.ml
+++ b/src/environment_setup/biopam.ml
@@ -68,6 +68,7 @@ let get_conda_env =
       ("distribute", `Version "0.6.45");
       ("fontconfig", `Version "2.11.1");
       ("freetype", `Version "2.5.5");
+      ("glpk", `Version "4.57");
       ("hdf5", `Version "1.8.15.1");
       ("htslib", `Version "1.3");
       ("libgcc", `Version "4.8.5");
@@ -302,7 +303,10 @@ let optitype =
     ~init_environment:KEDSL.Program.(
         fun ~install_path ->
           let name = Machine.Tool.(Default.optitype.Definition.name) in
-          shf "export OPAMROOT=%s" (Opam.root_of_package name |> Opam.root ~install_path)
+          let version = Machine.Tool.(Default.optitype.Definition.version) in
+          shf "export OPAMROOT=%s.%s"
+            (Opam.root_of_package name |> Opam.root ~install_path)
+            (match version with None -> "NOVERSION" | Some v -> v)
           && shf "export OPTITYPE_DATA=$(%s config var lib)/optitype"
             (Opam.bin ~install_path)
       )


### PR DESCRIPTION
These two fixes are needed to get the OptiType working again:

- the version postfix in the folder name generation was breaking how we built the path to the OptiType root
- glpk package that OptiType depends on is not always available with default distributions and even if it is, the relatively new versions do not play nicely with the OptiType. This fixes the version of the glpk package to the one that is compatible with OptiType (more details here: https://github.com/FRED-2/OptiType/issues/28)

Just realized that I completely forgot to push this fix out and make a PR off of it :\