### PR TITLE
Bump pyensembl version to make it compatible with the latest versions of pygenomics tools

### DIFF
--- a/src/environment_setup/python_package.ml
+++ b/src/environment_setup/python_package.ml
@@ -63,7 +63,7 @@ let create_python_tool ~host ~(run_program : Machine.Make_fun.t) ~install_path
 let default ~host ~run_program ~install_path () =
    Machine.Tool.Kit.of_list [
     create_python_tool ~host ~run_program ~install_path
-      ~version:"1.0.1" (Pip, Package_PyPI "pyensembl");
+      ~version:"1.1.0" (Pip, Package_PyPI "pyensembl");
     create_python_tool ~host ~run_program ~install_path
       ~version:"0.1.2" (Pip, Package_PyPI "vcf-annotate-polyphen");
     create_python_tool ~host ~run_program ~install_path


### PR DESCRIPTION
This new version comes with data structures and filenames for the cached data, so is needed for compatibility across all the pygenomics tools (including vaxrank, isovar, topiary, ...). This and `vaxrank` apparently became out-of-sync after #407 and vaxrank fails when the cache is coming from an older version of pyensembl.