### PR TITLE
Add fastq_of_input case for Input.t.Bam

### DIFF
--- a/src/examples/edsl_extension_register_result.ml
+++ b/src/examples/edsl_extension_register_result.ml
@@ -330,13 +330,13 @@ M*)
 let normal =
   Biokepi.EDSL.Library.Input.(
     fastq_sample "normal-1" [
-      of_bam `PE training_normal_bam ~reference_build:"b37";
+      fastq_of_bam `PE training_normal_bam ~reference_build:"b37";
     ]
   )
 let tumor =
   Biokepi.EDSL.Library.Input.(
     fastq_sample "tumor-1" [
-      of_bam `PE training_tumor_bam ~reference_build:"b37";
+      fastq_of_bam `PE training_tumor_bam ~reference_build:"b37";
     ]
   )
 (*M

--- a/src/pipeline_edsl/pipeline_library.mli
+++ b/src/pipeline_edsl/pipeline_library.mli
@@ -31,7 +31,7 @@ module Input : sig
 
   val se : ?fragment_id:string -> string -> fastq_fragment
 
-  val of_bam :
+  val fastq_of_bam :
     ?fragment_id: string ->
     ?sorted:[ `Coordinate | `Read_name ] ->
     reference_build:string ->
@@ -101,7 +101,7 @@ module Make:
 
     val bam_of_input_exn : Input.t -> [ `Bam ] Bfx.repr
 
-    val bwa_mem_opt_inputs:
+    val bwa_mem_opt_inputs_exn:
       Input.t ->
       [ `Bam of [ `Bam ] Bfx.repr * [ `PE | `SE ]
       | `Fastq of [ `Fastq ] Bfx.repr


### PR DESCRIPTION
Also rename Input.of_bam to fastq_of_bam

Improve error messages

this fixes an issue in epidisco with the no-realign option @julia326 