### PR TITLE
Bump topiary version and add multiple VCF support

### DIFF
--- a/src/environment_setup/python_package.ml
+++ b/src/environment_setup/python_package.ml
@@ -70,7 +70,7 @@ let default ~host ~run_program ~install_path () =
       ~version:"0.1.3" ~check_bin:"isovar-protein-sequences.py"
       (Pip, Package_PyPI "isovar");
     create_python_tool ~host ~run_program ~install_path
-      ~version:"0.1.1" (Pip, Package_PyPI "topiary");
+      ~version:"0.1.2" (Pip, Package_PyPI "topiary");
     create_python_tool ~host ~run_program ~install_path
       ~version:"0.4.0" (Pip, Package_PyPI "vaxrank");
    ]

--- a/src/environment_setup/python_package.ml
+++ b/src/environment_setup/python_package.ml
@@ -70,7 +70,7 @@ let default ~host ~run_program ~install_path () =
       ~version:"0.1.3" ~check_bin:"isovar-protein-sequences.py"
       (Pip, Package_PyPI "isovar");
     create_python_tool ~host ~run_program ~install_path
-      ~version:"0.0.21" (Pip, Package_PyPI "topiary");
+      ~version:"0.1.1" (Pip, Package_PyPI "topiary");
     create_python_tool ~host ~run_program ~install_path
       ~version:"0.4.0" (Pip, Package_PyPI "vaxrank");
    ]

--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -206,8 +206,9 @@ module Generic_optimizer
     fwd (Input.vcf_annotate_polyphen (bwd vcf))
   let isovar ?configuration vcf bam =
     fwd (Input.isovar ?configuration (bwd vcf) (bwd bam))
-  let topiary ?configuration vcf predictor alleles = 
-    fwd (Input.topiary ?configuration (bwd vcf) predictor (bwd alleles))
+  let topiary ?configuration vcfs predictor alleles = 
+    fwd (Input.topiary ?configuration 
+          (List.map ~f:bwd vcfs) predictor (bwd alleles))
   let vaxrank ?configuration vcfs bam predictor alleles =
     fwd (Input.vaxrank ?configuration
            (List.map ~f:(fun v -> (bwd v)) vcfs)

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -285,7 +285,7 @@ module type Bioinformatics_base = sig
 
   val topiary:
     ?configuration: Topiary.Configuration.t ->
-    [ `Vcf ] repr ->
+    [ `Vcf ] repr list ->
     Topiary.predictor_type ->
     [ `MHC_alleles ] repr ->
     [ `Topiary ] repr

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -279,15 +279,14 @@ module Make_serializer (How : sig
 
   let topiary
       ?(configuration = Tools.Topiary.Configuration.default)
-      vcf predictor alleles =
+      vcfs predictor alleles =
     fun ~(var_count : int) ->
-      let vcf_compiled = vcf ~var_count in
-      function_call "topiary" [
+      let vcfs_compiled = List.map vcfs ~f:(fun v -> v ~var_count) in
+      function_call "topiary" ([
         "configuration", string Tools.Topiary.Configuration.(name configuration);
         "alleles", alleles ~var_count;
         "predictor", string Tools.Topiary.(predictor_to_string predictor);
-        "vcf", vcf_compiled;
-      ]
+      ] @ (List.mapi ~f:(fun i v -> (sprintf "vcf%d" i, v)) vcfs_compiled))
 
   let vaxrank
     ?(configuration = Tools.Vaxrank.Configuration.default)

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -859,8 +859,7 @@ module Make (Config : Compiler_configuration)
       vcfs predictor alleles =
     let vs = List.map ~f:get_vcf vcfs in
     let refs = 
-      List.map ~f:(fun v -> v#product#reference_build)
-      |> List.dedup
+      vs |> List.map ~f:(fun v -> v#product#reference_build) |> List.dedup
     in
     let reference_build =
       if List.length refs > 1

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -868,20 +868,17 @@ module Make (Config : Compiler_configuration)
         ksprintf failwith "VCFs do not agree on their reference build: %s"
           (String.concat ~sep:", " refs)
       else
-        List.nth_exn refs
+        List.nth_exn refs 0
     in
     let mhc = get_mhc_alleles alleles in
-    let output_dir =
-      Name_file.in_directory ~readable_suffix:"topiary" Config.work_dir 
+    let output_file =
+      Name_file.in_directory ~readable_suffix:"topiary.tsv" Config.work_dir 
         ([
           Tools.Topiary.predictor_to_string predictor;
           Tools.Topiary.Configuration.name configuration;
           Filename.chop_extension (Filename.basename mhc#product#path);
-        ] @
-          (List.map vs ~f:(fun v -> v#product#path))
-        )
+        ] @ (List.map vs ~f:(fun v -> v#product#path)))
     in
-    let output_file = output_dir // "results.csv" in
     Topiary_result (
       Tools.Topiary.run
         ~configuration ~run_with


### PR DESCRIPTION
Depends on https://github.com/hammerlab/topiary/pull/67.

With this, we will be able to pass multiple VCFs to topiary and this will make it easier to include topiary in the pipeline (cf. https://github.com/hammerlab/epidisco/issues/158)