### PR TITLE
Add support for cleaning a BAM via Picard's CleanSam

### DIFF
--- a/src/pipeline_edsl/optimization_framework.ml
+++ b/src/pipeline_edsl/optimization_framework.ml
@@ -136,6 +136,9 @@ module Generic_optimizer
   let picard_reorder_sam ?mem_param ?reference_build bam =
     fwd (Input.picard_reorder_sam ?mem_param ?reference_build (bwd bam))
 
+  let picard_clean_bam bam =
+    fwd (Input.picard_clean_bam (bwd bam))
+
   let gatk_bqsr ?configuration bam =
     fwd (Input.gatk_bqsr ?configuration (bwd bam))
 

--- a/src/pipeline_edsl/semantics.ml
+++ b/src/pipeline_edsl/semantics.ml
@@ -179,6 +179,10 @@ module type Bioinformatics_base = sig
     [ `Bam ] repr ->
     [ `Bam ] repr
 
+  val picard_clean_bam:
+    [ `Bam ] repr ->
+    [ `Bam ] repr
+
   val gatk_bqsr:
     ?configuration : Gatk.Configuration.bqsr ->
     [ `Bam ] repr ->

--- a/src/pipeline_edsl/to_json.ml
+++ b/src/pipeline_edsl/to_json.ml
@@ -223,6 +223,9 @@ module Make_serializer (How : sig
       (sprintf "ref-%s"
          (match reference_build with None -> "inputs" | Some r -> r))
 
+  let picard_clean_bam =
+    one_to_one "picard_clean_bam" "default"
+      
   let gatk_bqsr ?(configuration = Tools.Gatk.Configuration.default_bqsr) =
     let (bqsr, preads) = configuration in
     one_to_one "gatk_bqsr"

--- a/src/pipeline_edsl/to_workflow.ml
+++ b/src/pipeline_edsl/to_workflow.ml
@@ -748,6 +748,18 @@ module Make (Config : Compiler_configuration)
         ~run_with ~input_bam output_bam_path
     )
 
+  let picard_clean_bam bam =
+    let input_bam = get_bam bam in
+    let output_bam_path =
+      Name_file.from_path 
+        input_bam#product#path
+        ~readable_suffix:"cleaned.bam"
+        []
+    in
+    Bam (
+      Tools.Picard.clean_bam ~run_with input_bam output_bam_path
+    )
+
   let gatk_bqsr ?(configuration = Tools.Gatk.Configuration.default_bqsr) bam =
     let input_bam = get_bam bam in
     let output_bam =


### PR DESCRIPTION
Useful workaround for the following issue with badly constructed BAM files:

```
Exception in thread "main" htsjdk.samtools.SAMFormatException: SAM validation error: ERROR: Read name HWI-D00419_209:1:1102:1640:75904, Read CIGAR M operator maps off end of reference
	at htsjdk.samtools.SAMUtils.processValidationErrors(SAMUtils.java:439)
	at htsjdk.samtools.BAMRecord.getCigar(BAMRecord.java:247)
	at htsjdk.samtools.SAMRecord.getAlignmentEnd(SAMRecord.java:460)
	at htsjdk.samtools.SAMRecord.computeIndexingBin(SAMRecord.java:1235)
	at htsjdk.samtools.SAMRecord.isValid(SAMRecord.java:1643)
	at htsjdk.samtools.BAMFileReader$BAMFileIterator.advance(BAMFileReader.java:642)
	at htsjdk.samtools.BAMFileReader$BAMFileIterator.next(BAMFileReader.java:628)
	at htsjdk.samtools.BAMFileReader$BAMFileIterator.next(BAMFileReader.java:598)
	at htsjdk.samtools.SamReader$AssertingIterator.next(SamReader.java:515)
	at htsjdk.samtools.SamReader$AssertingIterator.next(SamReader.java:489)
	at picard.sam.SamToFastq.doWork(SamToFastq.java:158)
	at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:187)
	at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:89)
	at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:99)
```