### PR TITLE
Make MuTect v1 great again

### DIFF
--- a/src/environment_setup/tool_providers.ml
+++ b/src/environment_setup/tool_providers.ml
@@ -415,9 +415,24 @@ let mutect_tool
   let tool = Machine.Tool.Default.mutect in
   let open KEDSL in
   let install_path = install_tools_path // Tool_def.to_directory_name tool in
+  let conda_env = (* mutect doesn't run on Java; so need to provide Java 7 *)
+    Conda.(setup_environment 
+      ~python_version:`Python2
+      ~base_packages:[("java-jdk", `Version "7.0.91")]
+      install_path 
+      "mutect_env")
+  in
+  let conda_ensure = Conda.(configured ~run_program ~host ~conda_env) in
+  let conda_init = Conda.init_env ~conda_env () in
   let get_mutect = get_broad_jar ~run_program ~host ~install_path loc in
-  Machine.Tool.create tool ~ensure:get_mutect
-    ~init:Program.(shf "export mutect_HOME=%s" install_path)
+  let edges = [depends_on conda_ensure; depends_on get_mutect] in
+  let ensure =
+    workflow_node without_product ~name:"MuTect setup" ~edges
+  in
+  let init = 
+    Program.(conda_init && shf "export mutect_HOME=%s" install_path)
+  in
+  Machine.Tool.create tool ~ensure ~init
 
 let gatk_tool
     ~(run_program : Machine.Make_fun.t)


### PR DESCRIPTION
@julia326 found out that mutect v1 has started failing since @smondet's recent migration of biokepi runners from Java 1.7 to 1.8 (c.f. https://github.com/hammerlab/secotrec/issues/64). This is apparently a well-known issue and has been acknowledged by Broad. 

This change wraps the mutect tool with a conda environment that comes with `openjdk-7.x` to make sure it keeps running no matter what the global Java version is.

(Tested and confirmed that this works as intended)