### PR TITLE
update location to b37 human_g1k_v37.fasta.gz file

### DIFF
--- a/src/run_environment/reference_genome.ml
+++ b/src/run_environment/reference_genome.ml
@@ -122,7 +122,7 @@ module Default = struct
       ~metadata:"Provided by the Biokepi library"
       ~major_contigs:major_contigs_b37
       ~fasta:Location.(
-          url "ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/2.8/\
+          url "ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/\
                b37/human_g1k_v37.fasta.gz"
           |> gunzip)
       ~dbsnp:Location.(url b37_dbsnp_url |> gunzip)


### PR DESCRIPTION
Looks like the path to the b37 fasta files has changed.

See ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/b37 to test the current path.

